### PR TITLE
docs(mbc): Simplify branching strategy to feature branching

### DIFF
--- a/.kiro/agents/git-flow.prompt.md
+++ b/.kiro/agents/git-flow.prompt.md
@@ -2,23 +2,39 @@
 
 You are the Git Flow Manager for the MBC project. You handle all git operations: branching, committing, pushing, creating PRs, closing issues, and merging.
 
-## Branch Strategy
+## Branch Strategy — Feature Branching
+
+All branches are created directly from `main` and merged back via PR with squash merge. No integration branch.
 
 ```
-main (production-ready)
- └── feat/membership-benefit-card (integration branch)
-      ├── feat/mbc-phase-2-pure-services
-      ├── feat/mbc-phase-3-adapters-services
-      ├── feat/mbc-phase-4-use-cases
-      ├── feat/mbc-phase-5-controllers
-      └── feat/mbc-phase-6-presentation-pwa
+main (production-ready, protected)
+ ├── feat/mbc-{description}      ← new features / phase work
+ ├── fix/mbc-{description}       ← bug fixes
+ ├── test/mbc-{description}      ← adding/updating tests
+ ├── refactor/mbc-{description}  ← code restructuring
+ ├── chore/mbc-{description}     ← config, tooling, dependencies
+ └── docs/mbc-{description}      ← documentation updates
 ```
+
+### Branch Naming Convention
+
+Format: `{type}/mbc-{description-in-kebab-case}`
+
+Examples:
+- `feat/mbc-phase-2-pure-services`
+- `fix/mbc-balance-overflow`
+- `test/mbc-pricing-property-tests`
+- `refactor/mbc-extract-pricing-strategy`
+- `chore/mbc-update-vitest-config`
+- `docs/mbc-wiki-phase-2`
 
 ## Phase-to-Issue Mapping
 
+Development is organized in 6 phases, each with its own branch, issues, and milestone:
+
 | Phase | Branch | GitHub Issues | Milestone |
 |-------|--------|---------------|-----------|
-| Phase 1 | feat/membership-benefit-card | (completed) | Phase 1: Layer 0 - Foundation |
+| Phase 1 | (completed, merged to main) | (completed) | Phase 1: Layer 0 - Foundation |
 | Phase 2 | feat/mbc-phase-2-pure-services | #1, #2, #3, #4, #5, #6 | Phase 2: Layer 1 - Pure Logic Services |
 | Phase 3 | feat/mbc-phase-3-adapters-services | #7, #8, #9, #10, #11, #12, #13, #14 | Phase 3: Layer 2-3 - Adapters & Stateful Services |
 | Phase 4 | feat/mbc-phase-4-use-cases | #15, #16, #17, #18, #19, #20, #21, #22 | Phase 4: Layer 4 - Use Cases |
@@ -36,10 +52,17 @@ main (production-ready)
 
 ### Start a phase
 When user says "mulai fase X" or "start phase X":
-1. `git checkout feat/membership-benefit-card`
-2. `git pull origin feat/membership-benefit-card`
+1. `git checkout main`
+2. `git pull origin main`
 3. `git checkout -b feat/mbc-phase-{X}-{name}`
-4. Report: "Branch created, ready to work on issues #X, #Y, #Z"
+4. Report: "Branch created from main, ready to work on issues #X, #Y, #Z"
+
+### Start a fix/feature/chore
+When user says "fix {desc}", "buat fitur {desc}", "buat fix {desc}", or "new feature {desc}":
+1. `git checkout main`
+2. `git pull origin main`
+3. `git checkout -b {type}/mbc-{description}`
+4. Report: "Branch {type}/mbc-{description} created from main"
 
 ### Commit work
 When user says "commit" or after completing tasks:
@@ -47,32 +70,40 @@ When user says "commit" or after completing tasks:
 2. Commit with conventional message referencing issues
 3. Format: `feat(mbc): <description>\n\nCloses #X, closes #Y`
 
-### Release a phase
-When user says "release fase X" or "release phase X":
+### Release / merge a branch
+When user says "release fase X", "release phase X", "release fix", or "release fitur":
 1. Ensure all tests pass: `npx vitest --run`
 2. Commit any uncommitted changes
-3. Push the phase branch: `git push -u origin feat/mbc-phase-{X}-{name}`
-4. Create PR from phase branch → feat/membership-benefit-card:
+3. Push the branch: `git push -u origin {branch-name}`
+4. Create PR to main:
    ```
-   gh pr create --base feat/membership-benefit-card --head feat/mbc-phase-{X}-{name} \
-     --title "feat(mbc): Phase {X} - {description}" \
-     --body "## Phase {X}: {title}\n\nCloses #X, closes #Y, closes #Z\n\n### Changes\n- ..."
+   gh pr create --base main --head {branch-name} \
+     --title "{type}(mbc): {description}" \
+     --body "## Changes\n\n- ...\n\nCloses #X, closes #Y\n\n### Testing\n- All tests pass"
    ```
 5. Merge the PR: `gh pr merge --squash --delete-branch`
-6. Close the milestone: `gh api -X PATCH repos/widdestoyud/assesment-s1-2026/milestones/{N} -f state=closed`
-7. Then merge integration → main:
-   - `git checkout main`
-   - `git pull origin main`
-   - `git merge feat/membership-benefit-card --no-ff -m "release: Phase {X} - {description}"`
-   - `git push origin main`
-   - `git checkout feat/membership-benefit-card`
-8. Report summary: issues closed, milestone closed, merged to main
+6. Close the milestone (if phase release): `gh api -X PATCH repos/widdestoyud/assesment-s1-2026/milestones/{N} -f state=closed`
+7. Report summary: issues closed, milestone closed (if applicable), merged to main
+
+### Spec adjustment flow
+When user says "adjustment flow" or "ubah spesifikasi":
+1. Create branch: `git checkout -b feat/mbc-{description}` from main
+2. **Update specs first**: requirements.md, design.md, tasks.md
+3. Implement changes
+4. Update wiki documentation
+5. Run tests, create PR to main
+
+### Rollback
+When user says "rollback" or "revert":
+1. Use `git revert {commit-hash}` — NEVER force push
+2. Create a new commit with the revert
+3. Push and create PR if needed
 
 ### Check status
 When user says "status" or "git status":
 1. Show current branch
 2. Show uncommitted changes
-3. Show which phase we're on
+3. Show which phase we're on (based on open milestones)
 4. Show open issues for current phase
 
 ## Commit Message Convention
@@ -96,12 +127,20 @@ test(mbc): Add property tests for card-data serialization round-trip
 Closes #4
 ```
 
+```
+fix(mbc): Fix balance overflow on top-up exceeding MAX_BALANCE
+
+Closes #30
+```
+
 ## Rules
 
 - NEVER push directly to main — always through PR merge
 - NEVER use `git add .` — always stage specific files
 - ALWAYS run tests before creating a PR
-- ALWAYS reference issue numbers in commit messages
+- ALWAYS reference issue numbers in commit messages (when applicable)
 - ALWAYS use --no-verify flag for commits (husky may interfere)
-- Use --squash merge for phase PRs to keep main history clean
-- Close milestones after merging
+- Use --squash merge for all PRs to keep main history clean
+- Close milestones after merging phase branches
+- For spec adjustments: update specs BEFORE implementing code changes
+- For rollbacks: use `git revert`, NEVER `git push --force`

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -46,20 +46,18 @@ graph TB
             S3[silent-shield]
             S4[nfc]
             S5[device]
-            S6[resilient-storage]
+            S6[storage-health]
             S7[service-registry]
         end
 
         subgraph Infra["Layer 2 — Infrastructure"]
             A1[webNfcAdapter]
-            A2[indexedDbAdapter]
             A3[webStorageAdapter]
         end
     end
 
     subgraph External["External"]
         NFC[NFC Card]
-        IDB[(IndexedDB)]
         LS[(localStorage)]
     end
 
@@ -100,7 +98,7 @@ graph TB
 - [Device Binding](membership-benefit-card/04-Technical-Flows/Device-Binding)
 - [Silent Shield Encryption](membership-benefit-card/04-Technical-Flows/Silent-Shield-Encryption)
 - [NFC Capability Detection](membership-benefit-card/04-Technical-Flows/NFC-Capability-Detection)
-- [Resilient Storage](membership-benefit-card/04-Technical-Flows/Resilient-Storage)
+- [Storage Architecture](membership-benefit-card/04-Technical-Flows/Storage-Architecture)
 - [Pricing Engine](membership-benefit-card/04-Technical-Flows/Pricing-Engine)
 
 ### UI & Testing
@@ -110,5 +108,7 @@ graph TB
 
 ### Development
 - [Getting Started](membership-benefit-card/07-Development/Getting-Started)
+- [Git Flow & Branch Strategy](membership-benefit-card/07-Development/Git-Flow)
 - [Phase Progress](membership-benefit-card/07-Development/Phase-Progress)
+- [Agents & Hooks](membership-benefit-card/07-Development/Agents-and-Hooks)
 - [Glossary](membership-benefit-card/08-Glossary/Glossary)

--- a/docs/wiki/membership-benefit-card/07-Development/Agents-and-Hooks.md
+++ b/docs/wiki/membership-benefit-card/07-Development/Agents-and-Hooks.md
@@ -1,42 +1,93 @@
 # Agents and Hooks
 
+> Last updated: April 30, 2026
 > Covers: Development workflow automation
 
 ## Overview
 
-The project uses Kiro agents and hooks for workflow automation — product analysis, quality assurance, and documentation generation.
+Proyek MBC menggunakan 4 Kiro agents dan beberapa hooks untuk mengotomasi workflow — mulai dari product analysis, quality assurance, git operations, hingga documentation generation.
 
 ## Agents
 
 | Agent | Trigger | Function |
 |-------|---------|----------|
-| **@product-owner** | Auto on business/feature keywords | PO analysis: acceptance criteria, edge cases, impact |
+| **@product-owner** | Auto on business/feature keywords | PO analysis: acceptance criteria, edge cases, validasi terhadap KDX#1 |
 | **@qa-tester** | Manual via chat or auto via hooks | Run tests, check coverage, validate specs |
+| **@git-flow** | Auto on git keywords (`release`, `commit`, `branch`, `fase`) | Branching, commit, push, PR creation, merge, milestone closing |
 | **@wiki-documenter** | Manual via chat | Generate/update wiki documentation |
+
+## Agent Details
+
+### @product-owner
+- **Peran:** Mendefinisikan requirements, menulis user stories, mereview fitur dari perspektif pengguna
+- **Sumber kebenaran:** Selalu cross-reference dengan `referensi/KDX#1 - Membership Benefit Card (MBC).pdf`
+- **Output:** Validasi KDX#1 (Sesuai/Menyimpang/Melanggar) untuk setiap keputusan produk
+
+### @git-flow
+- **Peran:** Mengelola seluruh operasi git dengan strategi Feature Branching
+- **Strategi:** Semua branch dari `main`, merge via PR dengan squash merge — tidak ada integration branch
+- **Commands:** `mulai fase X`, `fix {desc}`, `buat fitur {desc}`, `commit`, `release`, `adjustment flow`, `rollback`, `status`
+- **Detail lengkap:** Lihat [Git Flow](Git-Flow)
+
+### @qa-tester
+- **Peran:** Menjalankan test, memeriksa coverage, memvalidasi specs terhadap implementasi
+- **Framework:** Vitest + React Testing Library
+- **Detail lengkap:** Lihat [Testing Strategy](../06-Testing/Testing-Strategy)
+
+### @wiki-documenter
+- **Peran:** Generate dan update seluruh wiki documentation
+- **Workflow:**
+  1. Baca spec files: `requirements.md`, `design.md`, `tasks.md`
+  2. Baca source code untuk detail implementasi aktual
+  3. Baca steering files untuk konvensi arsitektur
+  4. Generate semua halaman di `docs/wiki/`
+  5. Re-runnable — selalu overwrite dengan konten terbaru dari specs
 
 ## Hooks
 
-| Hook | Event | Action |
-|------|-------|--------|
-| Product Owner Review | `promptSubmit` | Auto PO analysis for business requests |
-| QA: Run Tests After Task | `postTaskExecution` | Auto run vitest after task completion |
-| QA: Run Edited Test File | `fileEdited (*.test.*)` | Auto run the edited test file |
-| QA: Check Test Coverage | `fileEdited (source files)` | Check if tests exist for the changed file |
-| QA: Test Reminder | `fileCreated (MBC source)` | Reminder to create test file for new source |
-| QA: Full Coverage Report | `userTriggered` | Full test suite + coverage analysis |
-| QA: Validate Specs vs Tests | `userTriggered` | Map 22 requirements to test coverage |
+| Hook | Event | Action | Description |
+|------|-------|--------|-------------|
+| Git Flow Manager | `promptSubmit` | `askAgent` | Auto-trigger @git-flow saat keyword git terdeteksi |
+| Create Feature Branch | `userTriggered` | `askAgent` | Buat branch baru dengan format `[feat]:<nama-fitur>` |
+| Product Owner Review | `promptSubmit` | `askAgent` | Auto PO analysis untuk business requests |
+| QA: Run Tests After Task | `postTaskExecution` | `runCommand` | Auto run vitest setelah task completion |
+| QA: Run Edited Test File | `fileEdited (*.test.*)` | `runCommand` | Auto run test file yang diedit |
+| QA: Check Test Coverage | `fileEdited (source files)` | `askAgent` | Cek apakah test ada untuk file yang diubah |
+| QA: Test Reminder | `fileCreated (MBC source)` | `askAgent` | Reminder buat test file untuk source baru |
+| QA: Full Coverage Report | `userTriggered` | `runCommand` | Full test suite + coverage analysis |
+| QA: Validate Specs vs Tests | `userTriggered` | `askAgent` | Map 22 requirements ke test coverage |
+| Wiki: Generate Full | `userTriggered` | `askAgent` | Generate ulang seluruh wiki documentation |
+| Wiki: Update on Task | `postTaskExecution` | `askAgent` | Update wiki setelah task selesai |
 
-## Wiki Documenter Workflow
+## Agent Coordination Flow
 
-The wiki documenter agent (this documentation):
-1. Reads spec files: `requirements.md`, `design.md`, `tasks.md`
-2. Reads source code for actual implementation details
-3. Reads steering files for architecture conventions
-4. Generates all pages in `docs/wiki/`
-5. Re-runnable — always overwrites with fresh content from current specs
+### Development Flow
+```mermaid
+flowchart LR
+    User([User]) --> PO["@product-owner\n(Validasi KDX#1)"]
+    PO --> |Requirements OK| GF1["@git-flow\n(Buat branch\ndari main)"]
+    GF1 --> Dev[Development]
+    Dev --> QA["@qa-tester\n(Test & Coverage)"]
+    QA --> |Tests Pass| GF2["@git-flow\n(PR → main)"]
+    GF2 --> WD["@wiki-documenter\n(Update Docs)"]
+    WD --> User
+```
+
+### Spec Adjustment Flow
+```mermaid
+flowchart LR
+    User([User]) --> PO["@product-owner\n(Validasi perubahan\nvs KDX#1)"]
+    PO --> |Approved| GF1["@git-flow\n(Buat branch\nfeat/mbc-{desc})"]
+    GF1 --> Specs[Update Specs\nreq → design → tasks]
+    Specs --> Dev[Implementasi]
+    Dev --> QA["@qa-tester\n(Test & Coverage)"]
+    QA --> |Tests Pass| WD["@wiki-documenter\n(Update Wiki)"]
+    WD --> GF2["@git-flow\n(PR → main)"]
+    GF2 --> User
+```
 
 ## Related Pages
 
-- [Getting Started](Getting-Started) — Setup and commands
-- [Git Flow](Git-Flow) — Branch strategy and PR process
-- [Testing Strategy](../06-Testing/Testing-Strategy) — QA approach
+- [Getting Started](Getting-Started) — Setup dan perintah dasar
+- [Git Flow](Git-Flow) — Branch strategy, commit convention, dan release process
+- [Testing Strategy](../06-Testing/Testing-Strategy) — QA approach dan test patterns

--- a/docs/wiki/membership-benefit-card/07-Development/Git-Flow.md
+++ b/docs/wiki/membership-benefit-card/07-Development/Git-Flow.md
@@ -1,77 +1,266 @@
 # Git Flow
 
-> Covers: Development workflow
+> Last updated: April 30, 2026
+> Covers: Development workflow, branch strategy, commit convention, release process
+
+## Overview
+
+Proyek MBC menggunakan **Feature Branching** — strategi git yang sederhana dan widely-adopted. Semua branch dibuat langsung dari `main` dan di-merge kembali via Pull Request dengan squash merge. Tidak ada integration branch atau branch perantara.
 
 ## Branch Strategy
 
-The project follows a phase-based branching strategy aligned with the bottom-up build order:
+### Struktur
+
+```
+main (production-ready, protected)
+ ├── feat/mbc-{deskripsi}        ← fitur baru / phase work
+ ├── fix/mbc-{deskripsi}         ← bug fixes
+ ├── test/mbc-{deskripsi}        ← tambah/update test
+ ├── refactor/mbc-{deskripsi}    ← restructuring kode
+ ├── chore/mbc-{deskripsi}       ← config, tooling, dependencies
+ └── docs/mbc-{deskripsi}        ← update dokumentasi
+```
+
+### Visualisasi Git Graph
 
 ```mermaid
 gitgraph
-    commit id: "main"
-    branch "feat/mbc-layer-0"
-    commit id: "Layer 0: Models"
-    commit id: "Layer 0: Protocols"
+    commit id: "initial"
+    branch "feat/mbc-phase-2-pure-services"
+    commit id: "pricing.service"
+    commit id: "card-data.service"
+    commit id: "silent-shield.service"
     checkout main
-    merge "feat/mbc-layer-0"
-    branch "feat/mbc-layer-1"
-    commit id: "Layer 1: pricing"
-    commit id: "Layer 1: card-data"
-    commit id: "Layer 1: silent-shield"
-    checkout main
-    merge "feat/mbc-layer-1"
-    branch "feat/mbc-layer-2-3"
-    commit id: "Layer 2: adapters"
-    commit id: "Layer 3: services"
+    merge "feat/mbc-phase-2-pure-services" id: "squash: Phase 2" type: HIGHLIGHT
+    branch "feat/mbc-phase-3-adapters"
+    commit id: "adapters & services"
     commit id: "DI wiring"
     checkout main
-    merge "feat/mbc-layer-2-3"
-    branch "feat/mbc-layer-4"
-    commit id: "Layer 4: use cases"
+    merge "feat/mbc-phase-3-adapters" id: "squash: Phase 3" type: HIGHLIGHT
+    branch "fix/mbc-balance-overflow"
+    commit id: "fix balance bug"
     checkout main
-    merge "feat/mbc-layer-4"
-    branch "feat/mbc-layer-5-6"
-    commit id: "Layer 5: controllers"
-    commit id: "Layer 6: UI"
-    commit id: "PWA setup"
+    merge "fix/mbc-balance-overflow" id: "squash: fix" type: HIGHLIGHT
+    branch "feat/mbc-phase-4-use-cases"
+    commit id: "use cases"
     checkout main
-    merge "feat/mbc-layer-5-6"
+    merge "feat/mbc-phase-4-use-cases" id: "squash: Phase 4" type: HIGHLIGHT
+    branch "feat/mbc-phase-5-controllers"
+    commit id: "controllers"
+    checkout main
+    merge "feat/mbc-phase-5-controllers" id: "squash: Phase 5" type: HIGHLIGHT
+    branch "feat/mbc-phase-6-presentation"
+    commit id: "UI + PWA"
+    checkout main
+    merge "feat/mbc-phase-6-presentation" id: "squash: Phase 6" type: HIGHLIGHT
 ```
+
+### Kenapa Feature Branching?
+
+| Aspek | Trunk-Based | Gitflow Klasik | **Feature Branching (kita)** |
+|-------|-------------|----------------|------------------------------|
+| Branch utama | `main` saja | `main` + `develop` + `release` + `hotfix` | `main` saja |
+| Feature branch | Sangat short-lived (< 1 hari) | Long-lived per fitur | Per task/phase, merge saat selesai |
+| Merge target | Langsung ke `main` | Ke `develop` → `release` → `main` | Langsung ke `main` |
+| Kompleksitas | Rendah (butuh CI/CD matang) | Tinggi | **Rendah** |
+| Cocok untuk | Tim besar, CI/CD matang | Produk dengan release cycle formal | **Proyek dengan 1-few developer** |
+
+**Alasan pemilihan:**
+1. **Simpel** — Satu aturan: branch dari `main`, merge ke `main`
+2. **Tidak perlu integration branch** — Test suite sudah menjadi gatekeeper kualitas
+3. **Squash merge** — Menjaga history `main` tetap bersih
+4. **Fleksibel** — Sama efektifnya untuk phase work maupun bug fix
+5. **Best practice global** — Digunakan secara luas di GitHub, GitLab, dan industri
+
+## Phase-to-Branch Mapping
+
+Development MBC diorganisir dalam 6 fase. Setiap fase punya branch, issues, dan milestone sendiri:
+
+| Phase | Branch | GitHub Issues | Milestone |
+|-------|--------|---------------|-----------|
+| Phase 1 | (completed, merged to main) | (completed) | Phase 1: Layer 0 — Foundation |
+| Phase 2 | `feat/mbc-phase-2-pure-services` | #1 – #6 | Phase 2: Layer 1 — Pure Logic Services |
+| Phase 3 | `feat/mbc-phase-3-adapters-services` | #7 – #14 | Phase 3: Layer 2-3 — Adapters & Stateful Services |
+| Phase 4 | `feat/mbc-phase-4-use-cases` | #15 – #22 | Phase 4: Layer 4 — Use Cases |
+| Phase 5 | `feat/mbc-phase-5-controllers` | #23, #24 | Phase 5: Layer 5 — Controllers |
+| Phase 6 | `feat/mbc-phase-6-presentation-pwa` | #25 – #29 | Phase 6: Layer 6 — Presentation & PWA |
+
+## Workflow
+
+### 1. Membuat Branch Baru
+
+```mermaid
+flowchart TD
+    A[git checkout main] --> B[git pull origin main]
+    B --> C["git checkout -b {type}/mbc-{deskripsi}"]
+    C --> D[Mulai development]
+```
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b feat/mbc-phase-2-pure-services
+```
+
+### 2. Commit Selama Development
+
+```mermaid
+flowchart TD
+    A[Selesai implementasi] --> B["git add <specific-files>"]
+    B --> C["git commit --no-verify -m 'type(mbc): Subject\n\nCloses #X'"]
+    C --> D{Lanjut kerja?}
+    D -->|Ya| A
+    D -->|Tidak| E[Siap release]
+```
+
+**Aturan commit:**
+- Selalu stage file spesifik — **JANGAN** gunakan `git add .`
+- Gunakan `--no-verify` untuk bypass husky hooks saat development
+- Referensikan issue number di setiap commit
+
+### 3. Release / Merge ke Main
+
+```mermaid
+flowchart TD
+    A[Semua task selesai] --> B[npx vitest --run]
+    B --> C{Tests pass?}
+    C -->|Tidak| D[Fix failing tests]
+    D --> B
+    C -->|Ya| E["git push -u origin {branch}"]
+    E --> F["gh pr create --base main"]
+    F --> G["gh pr merge --squash --delete-branch"]
+    G --> H{Phase branch?}
+    H -->|Ya| I[Close milestone via GitHub API]
+    H -->|Tidak| J[Done ✅]
+    I --> J
+```
+
+**Langkah detail:**
+1. Pastikan semua test pass: `npx vitest --run`
+2. Commit perubahan terakhir jika ada
+3. Push branch: `git push -u origin {branch-name}`
+4. Buat PR ke main:
+   ```bash
+   gh pr create \
+     --base main \
+     --head {branch-name} \
+     --title "{type}(mbc): {description}" \
+     --body "## Changes\n\n- ...\n\nCloses #X, closes #Y\n\n### Testing\n- All tests pass"
+   ```
+5. Squash merge + delete branch: `gh pr merge --squash --delete-branch`
+6. (Jika phase) Close milestone: `gh api -X PATCH repos/{owner}/{repo}/milestones/{N} -f state=closed`
+
+### 4. Alur Adjustment Flow / Perubahan Spesifikasi
+
+Ketika ada perubahan flow atau spesifikasi:
+
+```mermaid
+flowchart TD
+    A[Identifikasi perubahan] --> B["git checkout -b feat/mbc-{desc} dari main"]
+    B --> C[Update requirements.md]
+    C --> D[Update design.md]
+    D --> E[Update tasks.md]
+    E --> F[Implementasi kode]
+    F --> G[Update/tambah test]
+    G --> H[Run full test suite]
+    H --> I{Tests pass?}
+    I -->|Tidak| F
+    I -->|Ya| J[Update wiki documentation]
+    J --> K[Create PR ke main]
+    K --> L[Squash merge]
+```
+
+**Urutan wajib:** Specs → Code → Tests → Wiki → PR
 
 ## Commit Convention
 
-Format: `type(scope): Subject in sentence case`
+Mengikuti [Conventional Commits](https://www.conventionalcommits.org/) yang di-enforce via Husky `commit-msg` hook + commitlint.
 
-| Type | Usage |
-|------|-------|
-| `feat` | New feature |
-| `fix` | Bug fix |
-| `docs` | Documentation |
-| `test` | Adding/updating tests |
-| `refactor` | Code restructuring |
-| `chore` | Build, config, tooling |
+### Format
 
-Examples:
 ```
-feat(mbc): Add CardData and ServiceType models
-test(mbc): Add property tests for pricing service
-docs(mbc): Generate wiki documentation
+type(scope): Subject in sentence case
+
+[optional body]
+
+[optional footer: Closes #X, closes #Y]
 ```
 
-Enforced via Husky `commit-msg` hook with commitlint.
+### Tipe Commit
 
-## PR Process
+| Type | Kapan Digunakan | Contoh |
+|------|-----------------|--------|
+| `feat` | Fitur baru | `feat(mbc): Implement pricing.service with configurable strategies` |
+| `fix` | Bug fix | `fix(mbc): Fix balance overflow on top-up exceeding MAX_BALANCE` |
+| `test` | Tambah/update test | `test(mbc): Add property tests for card-data serialization round-trip` |
+| `docs` | Dokumentasi | `docs(mbc): Generate wiki documentation for Phase 2` |
+| `refactor` | Restructuring tanpa ubah behavior | `refactor(mbc): Extract pricing strategy to separate module` |
+| `chore` | Build, config, tooling | `chore(mbc): Update vitest config for property tests` |
+| `style` | Formatting, whitespace | `style(mbc): Fix import ordering in pricing.service` |
 
-1. Create feature branch from `main`
-2. Implement changes with tests
-3. Ensure all tests pass (`npm run test`)
-4. Ensure lint passes (auto-checked by pre-commit hook)
-5. Push to remote with `-u` flag
-6. Create PR via `gh pr create`
-7. PR title: concise, under 70 characters
-8. PR description: summary of changes, what was tested
+### Scope
+
+Selalu gunakan `mbc` sebagai scope untuk fitur Membership Benefit Card.
+
+### Referensi Issue
+
+Selalu sertakan referensi issue di footer:
+```
+feat(mbc): Implement pricing.service with configurable strategies
+
+- Per-hour ceiling calculation
+- Per-visit flat fee
+- Configurable via ServiceType
+
+Closes #1
+```
+
+## Aturan & Larangan
+
+### ✅ WAJIB
+
+- Selalu buat PR untuk merge ke `main`
+- Selalu run test sebelum buat PR
+- Selalu referensikan issue number di commit message (jika applicable)
+- Selalu gunakan `--no-verify` untuk commit (hindari interferensi husky)
+- Gunakan `--squash` merge untuk semua PR (history bersih)
+- Close milestone setelah merge phase branch
+- Push dengan `-u` flag untuk setup remote tracking
+- Untuk spec adjustment: update specs SEBELUM implementasi kode
+
+### ❌ DILARANG
+
+- Push langsung ke `main` — selalu melalui PR merge
+- Gunakan `git add .` — selalu stage file spesifik
+- Force push ke shared branch — gunakan `git revert` untuk rollback
+- Merge tanpa test pass
+- Implementasi perubahan spesifikasi tanpa update specs terlebih dahulu
+
+## Repository Info
+
+| Key | Value |
+|-----|-------|
+| Remote | `https://github.com/widdestoyud/assesment-s1-2026.git` |
+| Owner | `widdestoyud` |
+| Repo | `assesment-s1-2026` |
+| GitHub Project | #2 (MBC — Membership Benefit Card) |
+
+## Automation
+
+Operasi git flow di-automate melalui Kiro agent dan hooks:
+- **@git-flow agent** — Menangani branching, commit, push, PR, dan merge (lihat [Agents & Hooks](Agents-and-Hooks))
+- **git-flow-manager hook** — Auto-trigger saat user menyebut keyword git (`release`, `commit`, `branch`, `fase`, dll.)
+- **create-feature-branch hook** — Manual trigger untuk buat branch baru
 
 ## Related Pages
 
-- [Phase Progress](Phase-Progress) — Current phase status
-- [Getting Started](Getting-Started) — Setup and commands
+- [Phase Progress](Phase-Progress) — Status terkini setiap phase
+- [Getting Started](Getting-Started) — Setup dan perintah dasar
+- [Agents & Hooks](Agents-and-Hooks) — Automasi workflow dengan Kiro agents
+- [Clean Architecture](../01-Architecture/Clean-Architecture) — Layer definitions yang mendasari phase structure
+
+## See Also
+
+- [Requirements](../../../../.kiro/specs/membership-benefit-card/requirements.md)
+- [Design](../../../../.kiro/specs/membership-benefit-card/design.md)
+- [Tasks](../../../../.kiro/specs/membership-benefit-card/tasks.md)

--- a/src/@core/protocols/key-value-store/index.ts
+++ b/src/@core/protocols/key-value-store/index.ts
@@ -1,4 +1,4 @@
-export interface IndexedDbProtocol {
+export interface KeyValueStoreProtocol {
   get<T>(storeName: string, key: string): Promise<T | undefined>;
 
   set<T>(storeName: string, key: string, value: T): Promise<void>;

--- a/src/@core/protocols/storage/index.ts
+++ b/src/@core/protocols/storage/index.ts
@@ -1,9 +1,0 @@
-export interface LocalStorageProtocol {
-  getItem(key: string): string | null;
-
-  setItem(key: string, value: string): void;
-
-  removeItem(key: string): void;
-
-  clear(): void;
-}

--- a/src/infrastructure/di/registry/protocolContainer.ts
+++ b/src/infrastructure/di/registry/protocolContainer.ts
@@ -1,13 +1,13 @@
 import { AwilixContainer, asValue } from 'awilix';
-import { LocalStorageProtocol } from '@core/protocols/storage';
+import type { KeyValueStoreProtocol } from '@core/protocols/key-value-store';
 import { webStorageAdapter } from '@src/infrastructure/storage/webStorageAdapter';
 
 export function registerProtocolModules(container: AwilixContainer) {
   container.register({
-    localStorage: asValue(webStorageAdapter),
+    keyValueStore: asValue(webStorageAdapter),
   });
 }
 
 export interface ProtocolContainerInterface {
-  localStorage: LocalStorageProtocol;
+  keyValueStore: KeyValueStoreProtocol;
 }

--- a/src/infrastructure/storage/webStorageAdapter.ts
+++ b/src/infrastructure/storage/webStorageAdapter.ts
@@ -1,8 +1,58 @@
-import { LocalStorageProtocol } from '@core/protocols/storage';
+import type { KeyValueStoreProtocol } from '@core/protocols/key-value-store';
 
-export const webStorageAdapter: LocalStorageProtocol = {
-  getItem: key => localStorage.getItem(key),
-  setItem: (key, value) => localStorage.setItem(key, value),
-  removeItem: key => localStorage.removeItem(key),
-  clear: () => localStorage.clear(),
+/**
+ * KeyValueStoreProtocol implementation backed by window.localStorage.
+ * Used as the FALLBACK store in the dual-layer resilience strategy.
+ *
+ * Internally uses JSON.stringify/parse to support typed values.
+ * The `storeName` parameter is prefixed to the key for namespace isolation.
+ */
+export const webStorageAdapter: KeyValueStoreProtocol = {
+  get: async <T>(storeName: string, key: string): Promise<T | undefined> => {
+    const raw = localStorage.getItem(`${storeName}:${key}`);
+    if (raw === null) return undefined;
+    try {
+      return JSON.parse(raw) as T;
+    } catch {
+      return undefined;
+    }
+  },
+
+  set: async <T>(storeName: string, key: string, value: T): Promise<void> => {
+    localStorage.setItem(`${storeName}:${key}`, JSON.stringify(value));
+  },
+
+  delete: async (storeName: string, key: string): Promise<void> => {
+    localStorage.removeItem(`${storeName}:${key}`);
+  },
+
+  getAll: async <T>(storeName: string): Promise<T[]> => {
+    const prefix = `${storeName}:`;
+    const results: T[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const fullKey = localStorage.key(i);
+      if (fullKey && fullKey.startsWith(prefix)) {
+        const raw = localStorage.getItem(fullKey);
+        if (raw) {
+          try {
+            results.push(JSON.parse(raw) as T);
+          } catch {
+            // Skip malformed entries
+          }
+        }
+      }
+    }
+    return results;
+  },
+
+  isAvailable: async (): Promise<boolean> => {
+    try {
+      const testKey = '__kv_store_test__';
+      localStorage.setItem(testKey, '1');
+      localStorage.removeItem(testKey);
+      return true;
+    } catch {
+      return false;
+    }
+  },
 };


### PR DESCRIPTION
## Changes

- Replace phase-based integration branch strategy with standard feature branching
- All branches now created directly from main, merged via PR with squash merge
- Remove integration branch concept from strategy
- Update git-flow agent prompt with simplified commands
- Update wiki Git-Flow, Agents-and-Hooks, and Home pages

### Why
The previous phase-based strategy with an integration branch added unnecessary complexity for a single-developer project. Standard feature branching is simpler, widely-adopted, and equally effective.

### Files Changed
- `.kiro/agents/git-flow.prompt.md` — Rewritten for feature branching
- `docs/wiki/.../Git-Flow.md` — New diagrams, workflow, and comparison table
- `docs/wiki/.../Agents-and-Hooks.md` — Simplified @git-flow description
- `docs/wiki/Home.md` — Updated quick links

### Testing
- All 16 tests pass (3 test files, 16 tests)