### PR TITLE
feat(mbc): Phase 3 — Adapters, stateful services, DI wiring

### DIFF
--- a/.kiro/agents/developer.json
+++ b/.kiro/agents/developer.json
@@ -1,0 +1,37 @@
+{
+  "name": "developer",
+  "description": "Senior Developer agent — writes production-quality TypeScript code following Clean Architecture, project patterns, and coding standards. Full read/write/build permission within this workspace. Supervised by @product-owner.",
+  "prompt": "file://developer.prompt.md",
+  "tools": [
+    "fs_read",
+    "fs_write",
+    "grep",
+    "glob",
+    "code",
+    "shell",
+    "knowledge"
+  ],
+  "allowedTools": [
+    "fs_read",
+    "fs_write",
+    "grep",
+    "glob",
+    "code",
+    "shell",
+    "knowledge"
+  ],
+  "resources": [
+    "file://src/**/*.ts",
+    "file://src/**/*.tsx",
+    "file://src/**/*.scss",
+    "file://.kiro/steering/**/*.md",
+    "file://.kiro/specs/**/*",
+    "file://package.json",
+    "file://tsconfig.json",
+    "file://vite.config.*",
+    "file://eslint.config.*",
+    "file://vitest.config.*"
+  ],
+  "keyboardShortcut": "ctrl+shift+d",
+  "welcomeMessage": "Developer mode aktif. Saya siap mengerjakan implementasi dengan presisi — read, write, build, test tanpa konfirmasi. Semua kode mengikuti Clean Architecture dan coding standards proyek ini. Task apa yang mau dikerjakan?"
+}

--- a/.kiro/agents/developer.prompt.md
+++ b/.kiro/agents/developer.prompt.md
@@ -1,0 +1,151 @@
+# Developer Agent — MBC Project
+
+You are the Senior Developer for the MBC (Membership Benefit Card) project. You write production-quality TypeScript code with precision, following the project's established patterns and Clean Architecture principles. You are autonomous within this workspace — read, write, build, and fix without asking for confirmation.
+
+## Scope & Permissions
+
+- **Scope:** This workspace only. All operations are confined to the project directory.
+- **Read/Write:** Full permission to read and write any file in this workspace without confirmation.
+- **Build:** You may run `npm run build`, `npx vitest --run`, `npm run lint`, and any project scripts. If a build error occurs due to your code (not external dependencies), fix it immediately without asking.
+- **External dependencies:** If a new npm package is needed, ASK the user first. Do not install packages autonomously.
+- **Git:** Do NOT commit, push, or create PRs. That is @git-flow's responsibility.
+
+## Supervision
+
+You work under the supervision of **@product-owner**. Before implementing any new feature or significant change:
+1. Check if the change aligns with the specs in `.kiro/specs/membership-benefit-card/` (requirements.md, design.md, tasks.md)
+2. If the change deviates from specs, flag it — do not proceed without user approval
+3. Follow the task order defined in tasks.md
+
+## Architecture Rules (MANDATORY)
+
+Read and follow these steering files before writing any code:
+- `.kiro/steering/architecture.md` — Clean Architecture layers, DI, controller pattern
+- `.kiro/steering/coding-standards.md` — Naming, imports, constants, styling, forms
+- `.kiro/steering/testing-standards.md` — Vitest patterns, coverage config
+
+### Layer Hierarchy
+
+```
+Layer 0 — Data Models & Schemas (pure types, zero dependencies)
+Layer 1 — Pure Logic Services (stateless: pricing, card-data, silent-shield)
+Layer 2 — I/O Adapters (webNfcAdapter, webStorageAdapter)
+Layer 3 — Stateful Services (nfc, device, storage-health, service-registry)
+Layer 4 — Use Cases (RegisterMember, CheckIn, CheckOut, etc.)
+Layer 5 — Controllers (pure functions via DI)
+Layer 6 — Presentation (Pages + Components)
+```
+
+**Dependencies flow inward only.** Layer N may only depend on Layer N-1 or lower. Never import upward.
+
+### Code Patterns
+
+#### Services (Layer 1-3)
+```typescript
+// Factory function pattern — NOT class-based
+export const ServiceName = (deps: Pick<AwilixRegistry, 'dep1' | 'dep2'>): ServiceInterface => {
+  const { dep1, dep2 } = deps;
+
+  const methodName = (params): ReturnType => {
+    // implementation
+  };
+
+  return { methodName };
+};
+```
+
+#### Controllers (Layer 5)
+```typescript
+// Pure factory function, import type ONLY
+import type { AwilixRegistry } from '@di/container';
+
+export interface ControllerInterface {
+  // only what the view needs
+}
+
+const Controller = (deps: Pick<AwilixRegistry, 'dep1' | 'dep2'>): ControllerInterface => {
+  // logic here
+};
+
+export default Controller;
+```
+
+#### DI Registration
+```typescript
+// Use asFunction for services/controllers, chain .singleton() for stateful
+container.register({
+  serviceName: asFunction(ServiceFactory).singleton(),
+});
+```
+
+### Naming Conventions
+
+| Item | Convention | Example |
+|------|-----------|---------|
+| Services | `kebab-case.service.ts` | `pricing.service.ts` |
+| Controllers | `kebab-case.controller.ts` | `gate.controller.ts` |
+| Models | `kebab-case.model.ts` | `card-data.model.ts` |
+| Tests | `[source].test.ts` | `pricing.service.test.ts` |
+| Components | `PascalCase/index.tsx` | `FeeBreakdown/index.tsx` |
+| SCSS Modules | `kebab-case.module.scss` | `fee-breakdown.module.scss` |
+| Constants | `UPPER_SNAKE_CASE` | `MBC_DEVICE_ID` |
+| Interfaces | `PascalCase` + `Interface` | `PricingServiceInterface` |
+| DI keys | `camelCase` | `pricingService` |
+
+### Import Rules
+
+- Use path aliases: `@core/*`, `@di/*`, `@controllers/*`, `@components/*`, `@utils/*`
+- Never use relative paths across layers
+- Import order: third-party → @core → @di → @src → @controllers → @components → @utils → relative → CSS
+
+## Quality Standards
+
+### Before Submitting Any Code
+
+1. **TypeScript:** Zero `any` types. Use proper generics, union types, or `unknown`.
+2. **Zod:** Validate all external data (NFC card data, localStorage, form inputs).
+3. **Error handling:** Every I/O operation must have explicit error handling. No unhandled promises.
+4. **Pure functions:** Layer 0-1 services must be pure — no side effects, no I/O.
+5. **Immutability:** Never mutate input parameters. Return new objects.
+6. **Tests:** Run `npx vitest --run` after implementing each service/module. Fix failures immediately.
+7. **Build:** Run `npm run build` periodically to catch type errors. Fix immediately.
+8. **Lint:** Ensure code passes ESLint. Use `npx eslint --fix` if needed.
+
+### Code Review Checklist (Self-Check)
+
+Before considering a task done:
+- [ ] Does it follow the factory function pattern (not class-based)?
+- [ ] Are all dependencies injected via AwilixRegistry?
+- [ ] Are all types explicit (no `any`, no implicit `any`)?
+- [ ] Are error cases handled with descriptive messages?
+- [ ] Does it respect layer boundaries (no upward imports)?
+- [ ] Are Zod schemas used for external data validation?
+- [ ] Do tests pass?
+- [ ] Does the build succeed?
+
+## Workflow
+
+When given a task:
+1. **Read** the relevant spec (requirements.md, design.md, tasks.md) for context
+2. **Read** existing code in the target layer to match patterns
+3. **Implement** following the architecture rules above
+4. **Test** — run vitest, fix any failures
+5. **Build** — run build, fix any type errors
+6. **Report** — summarize what was done, which files were created/modified
+
+## Project Context
+
+- **Tech stack:** React 19, TypeScript, Vite, TanStack Router, Awilix DI, Zod, Vitest
+- **NFC:** Web NFC API (NDEFReader) — Chrome Android 89+
+- **Encryption:** AES-256-GCM via Web Crypto API
+- **Storage:** localStorage via KeyValueStoreProtocol
+- **Styling:** SCSS Modules + Tailwind CSS 4
+- **Testing:** Vitest + React Testing Library + fast-check (property tests)
+
+## What You Do NOT Do
+
+- Do NOT commit or push code (that's @git-flow's job)
+- Do NOT modify specs without user approval (that's @product-owner's domain)
+- Do NOT install external packages without asking
+- Do NOT write documentation wiki pages (that's @wiki-documenter's job)
+- Do NOT skip tests or leave broken builds

--- a/.kiro/specs/membership-benefit-card/tasks.md
+++ b/.kiro/specs/membership-benefit-card/tasks.md
@@ -127,8 +127,8 @@ This plan implements the MBC feature following a strict bottom-up build order: d
 - [ ] 4. Checkpoint — Verify pure logic layer
   - Ensure all tests pass, ask the user if questions arise.
 
-- [ ] 5. Layer 2 — I/O adapters (protocol implementations)
-  - [ ] 5.1 Implement webNfcAdapter
+- [x] 5. Layer 2 — I/O adapters (protocol implementations)
+  - [x] 5.1 Implement webNfcAdapter
     - Create `src/infrastructure/nfc/webNfcAdapter.ts` implementing `NfcProtocol`
     - Wrap `NDEFReader` API: `isSupported()` checks `'NDEFReader' in window`
     - `requestPermission()` attempts a scan to trigger browser permission prompt
@@ -137,8 +137,8 @@ This plan implements the MBC feature following a strict bottom-up build order: d
     - Handle all Web NFC error types and map to `NfcError`
     - _Requirements: 2.1, 2.2, 2.4, 3.1_
 
-- [ ] 6. Layer 3 — Stateful services (compose pure logic + I/O adapters via DI)
-  - [ ] 6.1 Implement nfc.service
+- [x] 6. Layer 3 — Stateful services (compose pure logic + I/O adapters via DI)
+  - [x] 6.1 Implement nfc.service
     - Create `src/@core/services/mbc/nfc.service.ts` with `NfcServiceInterface` and `NfcService` factory function
     - Depends on `NfcProtocol` (via DI), `CardDataService`, `SilentShieldService`
     - `readCard()`: scan → read raw NDEF → return raw bytes
@@ -146,14 +146,14 @@ This plan implements the MBC feature following a strict bottom-up build order: d
     - `writeAndVerify(data)`: write → read back → compare → return `WriteVerifyResult`
     - _Requirements: 2.1, 3.1, 3.4, 3.7_
 
-  - [ ] 6.2 Implement storage-health.service
+  - [x] 6.2 Implement storage-health.service
     - Create `src/@core/services/mbc/storage-health.service.ts` with `StorageHealthServiceInterface` and `StorageHealthService` factory function
     - Depends on `KeyValueStoreProtocol` (via DI)
     - `isAvailable()`: check if localStorage is accessible and writable
     - `checkWriteCapacity()`: attempt a test write, detect quota exceeded errors, return `{ canWrite, error? }`
     - _Requirements: 20.2, 20.3, 20.4_
 
-  - [ ] 6.3 Implement device.service
+  - [x] 6.3 Implement device.service
     - Create `src/@core/services/mbc/device.service.ts` with `DeviceServiceInterface` and `DeviceService` factory function
     - Depends on `KeyValueStoreProtocol` (via DI)
     - `getDeviceId()`: read from localStorage via KeyValueStoreProtocol
@@ -162,7 +162,7 @@ This plan implements the MBC feature following a strict bottom-up build order: d
     - Handle storage write failures gracefully with `StorageError`
     - _Requirements: 19.1, 19.6, 19.7, 20.8_
 
-  - [ ] 6.4 Implement service-registry.service
+  - [x] 6.4 Implement service-registry.service
     - Create `src/@core/services/mbc/service-registry.service.ts` with `ServiceRegistryServiceInterface` and `ServiceRegistryService` factory function
     - Depends on `KeyValueStoreProtocol` (via DI)
     - Implement `getAll`, `getById`, `add`, `update`, `remove`, `initializeDefaults`
@@ -171,33 +171,33 @@ This plan implements the MBC feature following a strict bottom-up build order: d
     - Handle storage write failures gracefully with `StorageError`
     - _Requirements: 15.1, 15.2, 15.3, 15.4, 15.5, 15.6, 15.7, 20.5, 20.6, 20.8_
 
-  - [ ]* 6.5 Write unit tests for stateful services
+  - [x]* 6.5 Write unit tests for stateful services
     - Create `src/@core/services/__tests__/mbc/device.service.test.ts` — test Device_ID generation, persistence, regeneration warning, storage failure handling
     - Create `src/@core/services/__tests__/mbc/storage-health.service.test.ts` — test availability check, write capacity check, quota exceeded detection
     - Create `src/@core/services/__tests__/mbc/service-registry.service.test.ts` — test CRUD, default initialization, validation, storage failure handling
     - Mock `KeyValueStoreProtocol` via partial `AwilixRegistry`
     - _Requirements: 19.1, 19.7, 20.1, 20.2, 20.3, 20.4, 15.5, 15.6, 15.7, 20.8_
 
-- [ ] 7. Layer 2-3 — DI container registration
-  - [ ] 7.1 Create MBC protocol container
+- [x] 7. Layer 2-3 — DI container registration
+  - [x] 7.1 Create MBC protocol container
     - Create `src/infrastructure/di/registry/mbcProtocolContainer.ts`
     - Register `nfcProtocol` → `webNfcAdapter`
     - Export `MbcProtocolContainerInterface`
     - _Requirements: 2.1_
 
-  - [ ] 7.2 Create MBC service container
+  - [x] 7.2 Create MBC service container
     - Create `src/infrastructure/di/registry/mbcServiceContainer.ts`
     - Register all MBC services: `pricingService`, `cardDataService`, `silentShieldService`, `nfcService`, `deviceService`, `storageHealthService`, `serviceRegistryService`
     - Use `asFunction(...).singleton()` for stateful services
     - Export `MbcServiceContainerInterface`
     - _Requirements: 12.1, 13.1, 11.1, 2.1, 19.1, 20.1, 15.1_
 
-  - [ ] 7.3 Wire MBC containers into root container
+  - [x] 7.3 Wire MBC containers into root container
     - Update `src/infrastructure/di/container.ts` to import and call `registerMbcProtocolModules`, `registerMbcServiceModules`
     - Add `MbcProtocolContainerInterface` and `MbcServiceContainerInterface` to `AwilixRegistry` type union
     - _Requirements: all_
 
-- [ ] 8. Checkpoint — Verify services and DI wiring
+- [x] 8. Checkpoint — Verify services and DI wiring
   - Ensure all tests pass, ask the user if questions arise.
 
 - [ ] 9. Layer 4 — Use cases (orchestrate services)

--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ src/
 | Phase | Status | Deskripsi |
 |-------|--------|-----------|
 | Phase 1: Layer 0 | ✅ Done | Data models, types, Zod schemas, protocols |
-| Phase 2: Layer 1 | 🔲 Todo | Pure logic services (pricing, card-data, silent-shield) |
-| Phase 3: Layer 2-3 | 🔲 Todo | I/O adapters + stateful services + DI wiring |
+| Phase 2: Layer 1 | ✅ Done | Pure logic services (pricing, card-data, silent-shield) |
+| Phase 3: Layer 2-3 | 🔄 In Progress | I/O adapters + stateful services + DI wiring |
 | Phase 4: Layer 4 | 🔲 Todo | Use cases (Register, TopUp, CheckIn, CheckOut, dll) |
 | Phase 5: Layer 5 | 🔲 Todo | Controllers |
 | Phase 6: Layer 6 | 🔲 Todo | Components, pages, routing, PWA |
@@ -141,6 +141,8 @@ Proyek ini menggunakan custom agents untuk workflow automation:
 |-------|---------|--------|
 | **@product-owner** | Otomatis saat ada keyword bisnis/fitur | Analisis PO: acceptance criteria, edge cases, impact |
 | **@qa-tester** | Manual via chat atau otomatis via hooks | Jalankan test, cek coverage, validasi specs |
+| **@git-flow** | Otomatis saat ada keyword git (release, commit, branch, fase) | Branching, commit, push, PR, merge |
+| **@wiki-documenter** | Manual via chat | Generate/update wiki documentation |
 
 ### Hooks
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Proyek ini menggunakan custom agents untuk workflow automation:
 | Agent | Trigger | Fungsi |
 |-------|---------|--------|
 | **@product-owner** | Otomatis saat ada keyword bisnis/fitur | Analisis PO: acceptance criteria, edge cases, impact |
+| **@developer** | Manual via chat (`Ctrl+Shift+D`) | Implementasi kode: read, write, build, test — full permission |
 | **@qa-tester** | Manual via chat atau otomatis via hooks | Jalankan test, cek coverage, validasi specs |
 | **@git-flow** | Otomatis saat ada keyword git (release, commit, branch, fase) | Branching, commit, push, PR, merge |
 | **@wiki-documenter** | Manual via chat | Generate/update wiki documentation |

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -51,3 +51,8 @@
 
 **08 — Glossary**
 - [Glossary](membership-benefit-card/08-Glossary/Glossary)
+
+**09 — Laporan Fase**
+- [Fase 1: Data Models & Protocols](membership-benefit-card/09-Phase-Reports/Phase-1-Report)
+- [Fase 2: Pure Logic Services](membership-benefit-card/09-Phase-Reports/Phase-2-Report)
+- [Fase 3: Adapters & Stateful Services](membership-benefit-card/09-Phase-Reports/Phase-3-Report)

--- a/docs/wiki/membership-benefit-card/07-Development/Agents-and-Hooks.md
+++ b/docs/wiki/membership-benefit-card/07-Development/Agents-and-Hooks.md
@@ -12,6 +12,7 @@ Proyek MBC menggunakan 4 Kiro agents dan beberapa hooks untuk mengotomasi workfl
 | Agent | Trigger | Function |
 |-------|---------|----------|
 | **@product-owner** | Auto on business/feature keywords | PO analysis: acceptance criteria, edge cases, validasi terhadap KDX#1 |
+| **@developer** | Manual via chat (`Ctrl+Shift+D`) | Implementasi kode: read, write, build, test — full permission dalam workspace |
 | **@qa-tester** | Manual via chat or auto via hooks | Run tests, check coverage, validate specs |
 | **@git-flow** | Auto on git keywords (`release`, `commit`, `branch`, `fase`) | Branching, commit, push, PR creation, merge, milestone closing |
 | **@wiki-documenter** | Manual via chat | Generate/update wiki documentation |
@@ -22,6 +23,13 @@ Proyek MBC menggunakan 4 Kiro agents dan beberapa hooks untuk mengotomasi workfl
 - **Peran:** Mendefinisikan requirements, menulis user stories, mereview fitur dari perspektif pengguna
 - **Sumber kebenaran:** Selalu cross-reference dengan `referensi/KDX#1 - Membership Benefit Card (MBC).pdf`
 - **Output:** Validasi KDX#1 (Sesuai/Menyimpang/Melanggar) untuk setiap keputusan produk
+
+### @developer
+- **Peran:** Implementasi kode production-quality mengikuti Clean Architecture dan coding standards
+- **Permission:** Full read/write/build dalam workspace tanpa konfirmasi
+- **Batasan:** Tidak boleh commit/push (itu @git-flow), tidak boleh ubah specs tanpa approval (itu @product-owner), tidak boleh install package tanpa izin
+- **Supervisi:** Diawasi oleh @product-owner — semua implementasi harus sesuai specs
+- **Shortcut:** `Ctrl+Shift+D`
 
 ### @git-flow
 - **Peran:** Mengelola seluruh operasi git dengan strategi Feature Branching

--- a/docs/wiki/membership-benefit-card/07-Development/Phase-Progress.md
+++ b/docs/wiki/membership-benefit-card/07-Development/Phase-Progress.md
@@ -1,79 +1,336 @@
 # Phase Progress
 
+> Last updated: April 30, 2026
 > Covers: All requirements (implementation tracking)
 
 ## Overview
 
-The MBC feature is built in 6 phases following the bottom-up build order. Each phase corresponds to one or more architectural layers.
+Fitur MBC dibangun dalam 6 fase mengikuti bottom-up build order. Setiap fase membangun satu atau lebih layer arsitektur, dari data models hingga presentation.
 
 ## Phase Summary
 
 ```mermaid
 pie title Implementation Progress
     "Phase 1 — Layer 0 (Done)" : 5
-    "Phase 2 — Layer 1 (In Progress)" : 3
-    "Phase 3 — Layer 2-3 (Planned)" : 7
+    "Phase 2 — Layer 1 (Done)" : 3
+    "Phase 3 — Layer 2-3 (Done)" : 9
     "Phase 4 — Layer 4 (Planned)" : 8
     "Phase 5 — Layer 5 (Planned)" : 6
     "Phase 6 — Layer 6 (Planned)" : 20
 ```
 
-## Detailed Status
+---
 
-### Phase 1: Layer 0 — Data Models & Protocols ✅ Done
+## Phase 1: Layer 0 — Data Models & Protocols ✅ Done
+
+**Milestone:** [Phase 1: Layer 0 - Foundation](https://github.com/widdestoyud/assesment-s1-2026/milestone/1) (Closed)
+**Issues:** #31, #32, #33 (All closed)
+**Branch:** Merged to `main`
+
+### Ringkasan
+
+Fase 1 membangun fondasi proyek: tipe data, model domain, Zod validation schemas, konstanta, helper utilities, dan protocol interfaces. Semua modul di layer ini adalah pure types tanpa dependency — menjadi "bricks" yang digunakan oleh semua layer di atasnya.
+
+### Tasks
 
 | Task | Status | Description |
 |------|--------|-------------|
-| 1.1 | ✅ Done | MBC constants and storage keys |
-| 1.2 | ✅ Done | Data model interfaces and Zod schemas |
+| 1.1 | ✅ Done | MBC constants dan storage keys |
+| 1.2 | ✅ Done | Data model interfaces dan Zod schemas |
 | 1.3 | ✅ Done | MBC helper utilities (formatIDR, formatDuration) |
 | 2.1 | ✅ Done | NfcProtocol interface |
-| 2.2 | ✅ Done | ~~IndexedDbProtocol interface~~ (Removed — simplified to localStorage-only) |
+| 2.2 | ✅ Done | ~~IndexedDbProtocol~~ (Removed — simplified to localStorage-only via KeyValueStoreProtocol) |
 
-**Files created:**
-- `src/utils/constants/mbc-keys.ts`
-- `src/@core/services/mbc/models/card-data.model.ts`
-- `src/@core/services/mbc/models/service-type.model.ts`
-- `src/@core/services/mbc/models/common.model.ts`
-- `src/@core/services/mbc/models/schemas.ts`
-- `src/@core/services/mbc/models/index.ts`
-- `src/utils/helpers/mbc.helper.ts`
-- `src/@core/protocols/nfc/index.ts`
+### Files Created
 
-### Phase 2: Layer 1 — Pure Logic Services 🔄 In Progress
+| File | Purpose |
+|------|---------|
+| `src/utils/constants/mbc-keys.ts` | Storage keys, Silent Shield config constants |
+| `src/@core/services/mbc/models/card-data.model.ts` | CardData, MemberIdentity, CheckInStatus, TransactionLogEntry |
+| `src/@core/services/mbc/models/service-type.model.ts` | ServiceType, PricingStrategy, DEFAULT_PARKING_SERVICE |
+| `src/@core/services/mbc/models/common.model.ts` | RoleMode, NfcStatus, NfcError, FeeResult, AtomicWriteResult, dll |
+| `src/@core/services/mbc/models/schemas.ts` | Zod schemas: CardDataSchema, ServiceTypeFormSchema, dll |
+| `src/@core/services/mbc/models/index.ts` | Barrel export untuk semua models |
+| `src/utils/helpers/mbc.helper.ts` | formatIDR, formatDuration, ISO timestamp helpers |
+| `src/@core/protocols/nfc/index.ts` | NfcProtocol interface (isSupported, requestPermission, startScan, write) |
+| `src/@core/protocols/key-value-store/index.ts` | KeyValueStoreProtocol interface (get, set, delete, getAll, isAvailable) |
+
+### Requirements Covered
+
+Req 1.1, 12.2-3, 13.1, 15.2, 19.1, 19.6, 20.1, 2.1, 2.2, 2.4, 3.1, 8.9, 9.3
+
+### Keputusan Arsitektur
+
+- **IndexedDB dihapus** — Disederhanakan ke localStorage-only via `KeyValueStoreProtocol`. Alasan: data yang perlu di-persist hanya Device_ID dan Service Registry (kecil), tidak perlu IndexedDB.
+- **Zod untuk validasi** — Semua data eksternal (NFC card, localStorage) divalidasi dengan Zod schema sebelum digunakan.
+- **Barrel exports** — Semua model di-export dari `models/index.ts` untuk clean imports.
+
+---
+
+## Phase 2: Layer 1 — Pure Logic Services ✅ Done
+
+**Milestone:** [Phase 2: Layer 1 - Pure Logic Services](https://github.com/widdestoyud/assesment-s1-2026/milestone/2) (Closed)
+**Issues:** #1 – #6 (All closed)
+**Branch:** Merged to `main`
+
+### Ringkasan
+
+Fase 2 mengimplementasikan 3 pure logic services yang menjadi inti bisnis MBC. Semua service di layer ini adalah **stateless pure functions** — tidak ada I/O, tidak ada side effects, tidak ada dependency ke browser API. Ini memungkinkan testing yang cepat dan reliable.
+
+### Tasks
 
 | Task | Status | Description |
 |------|--------|-------------|
-| 3.1 | 🔄 In Progress | pricing.service implementation |
-| 3.2* | 📋 Planned | Property tests: Ceiling Rounding (P8) |
-| 3.3* | 📋 Planned | Property tests: Pricing Consistency (P9) |
-| 3.4 | 📋 Planned | card-data.service implementation |
-| 3.5* | 📋 Planned | Property tests: Serialization Round-Trip (P1) |
-| 3.6* | 📋 Planned | Property tests: Balance Conservation Top-Up (P3) |
-| 3.7* | 📋 Planned | Property tests: Balance Conservation Check-Out (P4) |
-| 3.8* | 📋 Planned | Property tests: Exactly-Once Deduction (P5) |
-| 3.9* | 📋 Planned | Property tests: Check-In Exclusivity (P6) |
-| 3.10* | 📋 Planned | Property tests: Transaction Log Bounded (P7) |
-| 3.11 | 📋 Planned | silent-shield.service implementation |
-| 3.12* | 📋 Planned | Property tests: Encryption Round-Trip (P2) |
+| 3.1 | ✅ Done | pricing.service — kalkulasi tarif per service type |
+| 3.2* | ✅ Done | Property tests: Ceiling Rounding (P8) |
+| 3.3* | ✅ Done | Property tests: Pricing Consistency (P9) |
+| 3.4 | ✅ Done | card-data.service — serialize/deserialize/mutate CardData |
+| 3.5* | ✅ Done | Property tests: Serialization Round-Trip (P1) |
+| 3.6* | ✅ Done | Property tests: Balance Conservation Top-Up (P3) |
+| 3.7* | ✅ Done | Property tests: Balance Conservation Check-Out (P4) |
+| 3.8* | ✅ Done | Property tests: Exactly-Once Deduction (P5) |
+| 3.9* | ✅ Done | Property tests: Check-In Exclusivity (P6) |
+| 3.10* | ✅ Done | Property tests: Transaction Log Bounded (P7) |
+| 3.11 | ✅ Done | silent-shield.service — AES-256-GCM encrypt/decrypt |
+| 3.12* | ✅ Done | Property tests: Encryption Round-Trip (P2) |
 
-**Note:** Tasks marked with `*` are optional property tests.
+### Files Created
 
-### Phase 3: Layer 2-3 — I/O Adapters & Stateful Services 📋 Planned
+| File | Purpose |
+|------|---------|
+| `src/@core/services/mbc/pricing.service.ts` | calculateFee(strategy, checkIn, checkOut) → FeeResult |
+| `src/@core/services/mbc/card-data.service.ts` | serialize, deserialize, validate, applyRegistration, applyTopUp, applyCheckIn, applyCheckOut, appendTransactionLog |
+| `src/@core/services/mbc/silent-shield.service.ts` | encrypt(data) → Uint8Array, decrypt(data) → Uint8Array |
+| `src/@core/services/__tests__/mbc/pricing.service.test.ts` | 6 tests (property-based + unit) |
+| `src/@core/services/__tests__/mbc/card-data.service.test.ts` | 9 tests (property-based + unit) |
+| `src/@core/services/__tests__/mbc/silent-shield.service.test.ts` | 1 test (encryption round-trip) |
+
+### Test Coverage
+
+| Service | Tests | Technique | Properties Validated |
+|---------|-------|-----------|---------------------|
+| pricing.service | 6 | fast-check property tests | P8 (Ceiling Rounding), P9 (Pricing Consistency) |
+| card-data.service | 9 | fast-check property tests | P1 (Round-Trip), P3 (Balance Top-Up), P4 (Balance Check-Out), P5 (Exactly-Once), P6 (Check-In Exclusivity), P7 (Transaction Log Bounded) |
+| silent-shield.service | 1 | fast-check property test | P2 (Encryption Round-Trip) |
+
+**Total: 16 tests, all passing**
+
+### Requirements Covered
+
+Req 5.2, 6.2, 6.3, 8.6, 8.8, 10.1, 10.2, 11.1-4, 12.1-7, 13.1-5, 18.7
+
+### Keputusan Arsitektur
+
+- **Factory function pattern** — Semua service menggunakan factory function `(deps: AwilixRegistry) => Interface`, bukan class. Ini memudahkan DI dan testing.
+- **Immutability** — Semua mutation functions (applyTopUp, applyCheckIn, dll) mengembalikan objek baru, tidak pernah mutate input.
+- **crypto-browserify** — Digunakan untuk AES-256-GCM karena sudah ada sebagai polyfill di proyek. Key derivation via PBKDF2 dengan 100.000 iterasi.
+- **Transaction log bounded** — Max 5 entries, oldest removed first (FIFO).
+
+---
+
+## Phase 3: Layer 2-3 — I/O Adapters & Stateful Services ✅ Done
+
+**Milestone:** [Phase 3: Layer 2-3 - Adapters & Stateful Services](https://github.com/widdestoyud/assesment-s1-2026/milestone/3)
+**Issues:** #7 – #14
+**Branch:** `feat/mbc-phase-3-adapters-services`
+
+### Ringkasan
+
+Fase 3 membangun layer I/O (adapter untuk browser API) dan stateful services yang mengkomposisi pure logic dari Layer 1 dengan I/O adapters via dependency injection. Fase ini juga menyelesaikan DI wiring — mendaftarkan semua MBC protocols dan services ke Awilix container.
+
+### Tasks
 
 | Task | Status | Description |
 |------|--------|-------------|
-| 5.1 | 📋 Planned | webNfcAdapter (NDEFReader wrapper) |
-| 6.1 | 📋 Planned | nfc.service |
-| 6.2 | 📋 Planned | storage-health.service |
-| 6.3 | 📋 Planned | device.service |
-| 6.4 | 📋 Planned | service-registry.service |
-| 6.5* | 📋 Planned | Unit tests for stateful services |
-| 7.1 | 📋 Planned | MBC protocol DI container |
-| 7.2 | 📋 Planned | MBC service DI container |
-| 7.3 | 📋 Planned | Wire into root container |
+| 5.1 | ✅ Done | webNfcAdapter — NDEFReader wrapper implementing NfcProtocol |
+| 6.1 | ✅ Done | nfc.service — readCard, writeCard, writeAndVerify |
+| 6.2 | ✅ Done | storage-health.service — isAvailable, checkWriteCapacity |
+| 6.3 | ✅ Done | device.service — getDeviceId, ensureDeviceId |
+| 6.4 | ✅ Done | service-registry.service — CRUD + initializeDefaults |
+| 6.5* | ✅ Done | Unit tests untuk semua stateful services |
+| 7.1 | ✅ Done | MBC protocol DI container (nfcProtocol) |
+| 7.2 | ✅ Done | MBC service DI container (7 services) |
+| 7.3 | ✅ Done | Wire MBC containers ke root Awilix container |
 
-### Phase 4: Layer 4 — Use Cases 📋 Planned
+### Files Created
+
+**Layer 2 — I/O Adapter:**
+
+| File | Purpose |
+|------|---------|
+| `src/infrastructure/nfc/webNfcAdapter.ts` | Wraps browser NDEFReader API behind NfcProtocol interface. Handles scan, write, permission request. Encodes data as base64 NDEF text records. |
+| `types/web-nfc.d.ts` | TypeScript type declarations untuk Web NFC API (NDEFReader, NDEFMessage, NDEFRecord, dll) |
+
+**Layer 3 — Stateful Services:**
+
+| File | Purpose |
+|------|---------|
+| `src/@core/services/mbc/nfc.service.ts` | High-level NFC operations: readCard (one-shot scan → resolve), writeCard, writeAndVerify (write → read-back → compare) |
+| `src/@core/services/mbc/storage-health.service.ts` | Deteksi ketersediaan localStorage, test write capacity, deteksi QuotaExceededError |
+| `src/@core/services/mbc/device.service.ts` | Device_ID lifecycle: get from storage, generate via crypto.randomUUID() if missing, persist, flag wasRegenerated |
+| `src/@core/services/mbc/service-registry.service.ts` | CRUD untuk Service Type configurations. Validasi dengan Zod, filter corrupted entries, initialize defaults (parking) |
+
+**DI Wiring:**
+
+| File | Purpose |
+|------|---------|
+| `src/infrastructure/di/registry/mbcProtocolContainer.ts` | Register `nfcProtocol` → `webNfcAdapter` |
+| `src/infrastructure/di/registry/mbcServiceContainer.ts` | Register 7 MBC services (3 stateless + 4 singleton) |
+| `src/infrastructure/di/container.ts` (modified) | Wire MBC containers, update AwilixRegistry type |
+
+**Tests:**
+
+| File | Tests | Scenarios Covered |
+|------|-------|-------------------|
+| `src/@core/services/__tests__/mbc/nfc.service.test.ts` | 14 | isAvailable (true/false), requestPermission (granted/denied/unsupported), readCard (success/error), writeCard (success/error), writeAndVerify (match/mismatch/write-error/read-error/empty-data) |
+| `src/@core/services/__tests__/mbc/storage-health.service.test.ts` | 8 | isAvailable (true/false), checkWriteCapacity (healthy/unavailable/mismatch/quota-exceeded/generic-error/cleanup) |
+| `src/@core/services/__tests__/mbc/device.service.test.ts` | 6 | getDeviceId (exists/missing), ensureDeviceId (existing/generate-new/idempotent/storage-error) |
+| `src/@core/services/__tests__/mbc/service-registry.service.test.ts` | 17 | initializeDefaults (empty/existing), getAll (normal/empty/corrupted-filter), getById (found/not-found), add (valid/duplicate/invalid), update (valid/not-found/preserve-id/invalid-after-update), remove (valid/not-found/last-item) |
+
+### Test Coverage Summary
+
+```mermaid
+pie title Phase 3 Test Distribution
+    "nfc.service" : 14
+    "storage-health.service" : 8
+    "device.service" : 6
+    "service-registry.service" : 17
+```
+
+**Total fase 3: 45 tests baru, semua passing**
+**Total kumulatif: 61 tests (16 fase 2 + 45 fase 3)**
+
+### Test Scenarios Detail
+
+#### nfc.service (14 tests)
+
+| Category | Scenario | Type |
+|----------|----------|------|
+| ✅ Positive | isAvailable returns true when supported | Unit |
+| ✅ Positive | requestPermission returns granted | Unit |
+| ✅ Positive | readCard resolves with data from first scan | Async |
+| ✅ Positive | writeCard delegates to protocol | Unit |
+| ✅ Positive | writeAndVerify succeeds when data matches | Async |
+| ✅ Positive | writeAndVerify handles empty arrays | Edge |
+| ❌ Negative | isAvailable returns false when unsupported | Unit |
+| ❌ Negative | requestPermission returns denied | Unit |
+| ❌ Negative | requestPermission returns unsupported | Unit |
+| ❌ Negative | readCard rejects on NFC error | Async |
+| ❌ Negative | writeCard propagates errors | Async |
+| ❌ Negative | writeAndVerify fails on data mismatch | Async |
+| ❌ Negative | writeAndVerify fails on write error | Async |
+| ❌ Negative | writeAndVerify fails on verification read error | Async |
+
+#### storage-health.service (8 tests)
+
+| Category | Scenario | Type |
+|----------|----------|------|
+| ✅ Positive | isAvailable returns true | Unit |
+| ✅ Positive | checkWriteCapacity returns canWrite: true | Unit |
+| ✅ Positive | cleanup test key after check | Edge |
+| ❌ Negative | isAvailable returns false | Unit |
+| ❌ Negative | unavailable error when storage not accessible | Unit |
+| ❌ Negative | write_failed when read-back mismatch | Edge |
+| ❌ Negative | quota_exceeded on QuotaExceededError | Edge |
+| ❌ Negative | write_failed on generic error | Edge |
+
+#### device.service (6 tests)
+
+| Category | Scenario | Type |
+|----------|----------|------|
+| ✅ Positive | getDeviceId returns stored ID | Unit |
+| ✅ Positive | ensureDeviceId returns existing without regeneration | Unit |
+| ✅ Positive | ensureDeviceId generates new ID when missing | Unit |
+| ✅ Positive | ensureDeviceId is idempotent (wasRegenerated false on second call) | Edge |
+| ❌ Negative | getDeviceId returns undefined when not stored | Unit |
+| ❌ Negative | ensureDeviceId propagates storage write errors | Edge |
+
+#### service-registry.service (17 tests)
+
+| Category | Scenario | Type |
+|----------|----------|------|
+| ✅ Positive | initializeDefaults creates parking service | Unit |
+| ✅ Positive | getAll returns all service types | Unit |
+| ✅ Positive | getById returns found service | Unit |
+| ✅ Positive | add valid service type | Unit |
+| ✅ Positive | update existing service type | Unit |
+| ✅ Positive | update preserves original ID | Edge |
+| ✅ Positive | remove existing service type | Unit |
+| ✅ Positive | remove last item leaves empty registry | Edge |
+| ❌ Negative | initializeDefaults skips when registry exists | Unit |
+| ❌ Negative | getAll returns empty when no registry | Unit |
+| ❌ Negative | getAll filters corrupted entries | Edge |
+| ❌ Negative | getById returns undefined when not found | Unit |
+| ❌ Negative | add throws on duplicate ID | Unit |
+| ❌ Negative | add throws on invalid data | Unit |
+| ❌ Negative | update throws when not found | Unit |
+| ❌ Negative | update throws on invalid result | Edge |
+| ❌ Negative | remove throws when not found | Unit |
+
+### Requirements Covered
+
+| Requirement | Service | Description |
+|-------------|---------|-------------|
+| Req 2.1, 2.2, 2.4, 3.1 | webNfcAdapter | NFC read/write/permission |
+| Req 3.4, 3.7 | nfc.service | Write verification |
+| Req 19.1, 19.6, 19.7 | device.service | Device_ID lifecycle |
+| Req 15.1-7 | service-registry.service | Service type CRUD |
+| Req 20.2-4, 20.5-6, 20.8 | storage-health.service, service-registry.service | Storage error handling |
+
+### Keputusan Arsitektur
+
+- **Base64 encoding untuk NFC** — Card data di-encode sebagai base64 string dalam NDEF text record. Ini memastikan kompatibilitas dengan NDEF format yang hanya mendukung text/URL records.
+- **One-shot readCard** — `readCard()` mengembalikan Promise yang resolve pada first scan, lalu abort session. Ini mencegah multiple reads yang tidak diinginkan.
+- **Singleton untuk stateful services** — nfc.service, device.service, storage-health.service, dan service-registry.service di-register sebagai singleton di DI container karena mereka menyimpan state atau cache.
+- **Zod validation pada read** — service-registry.service memvalidasi setiap entry saat membaca dari localStorage, dan memfilter entries yang corrupted. Ini mencegah crash akibat data rusak.
+- **QuotaExceededError detection** — storage-health.service mendeteksi quota exceeded di Chrome (`QuotaExceededError`), Firefox, dan Safari (legacy code 22).
+- **crypto.randomUUID()** — Digunakan untuk generate Device_ID karena tersedia di semua browser modern dan menghasilkan UUID v4 yang cryptographically random.
+
+### Dependency Graph (Phase 3)
+
+```mermaid
+graph TB
+    subgraph "Layer 2 — I/O Adapters"
+        WNA[webNfcAdapter]
+        WSA[webStorageAdapter<br/>existing]
+    end
+
+    subgraph "Layer 3 — Stateful Services"
+        NS[nfc.service]
+        DS[device.service]
+        SHS[storage-health.service]
+        SRS[service-registry.service]
+    end
+
+    subgraph "Protocols"
+        NP[NfcProtocol]
+        KVP[KeyValueStoreProtocol]
+    end
+
+    subgraph "DI Container"
+        MPC[mbcProtocolContainer]
+        MSC[mbcServiceContainer]
+        ROOT[container.ts]
+    end
+
+    WNA -.implements.-> NP
+    WSA -.implements.-> KVP
+    NS --> NP
+    DS --> KVP
+    SHS --> KVP
+    SRS --> KVP
+    MPC --> WNA
+    MSC --> NS
+    MSC --> DS
+    MSC --> SHS
+    MSC --> SRS
+    ROOT --> MPC
+    ROOT --> MSC
+```
+
+---
+
+## Phase 4: Layer 4 — Use Cases 📋 Planned
 
 | Task | Status | Description |
 |------|--------|-------------|
@@ -88,7 +345,7 @@ pie title Implementation Progress
 | 9.9* | 📋 Planned | Unit tests for use cases |
 | 11.1 | 📋 Planned | Use case DI container |
 
-### Phase 5: Layer 5 — Controllers 📋 Planned
+## Phase 5: Layer 5 — Controllers 📋 Planned
 
 | Task | Status | Description |
 |------|--------|-------------|
@@ -100,7 +357,7 @@ pie title Implementation Progress
 | 12.6 | 📋 Planned | Controller DI container |
 | 12.7* | 📋 Planned | Controller unit tests |
 
-### Phase 6: Layer 6 — Presentation & PWA 📋 Planned
+## Phase 6: Layer 6 — Presentation & PWA 📋 Planned
 
 | Task | Status | Description |
 |------|--------|-------------|
@@ -112,20 +369,31 @@ pie title Implementation Progress
 | 18.2 | 📋 Planned | Web app manifest |
 | 18.3* | 📋 Planned | Offline integration test |
 
+---
+
 ## Completion Summary
 
-| Phase | Required Tasks | Optional Tasks | Done | Progress |
-|-------|---------------|----------------|------|----------|
-| Phase 1 | 5 | 0 | 5 | ✅ 100% |
-| Phase 2 | 3 | 9 | 0 | 🔄 ~25% |
-| Phase 3 | 7 | 1 | 0 | 📋 0% |
-| Phase 4 | 8 | 2 | 0 | 📋 0% |
-| Phase 5 | 6 | 1 | 0 | 📋 0% |
-| Phase 6 | 18 | 2 | 0 | 📋 0% |
-| **Total** | **47** | **15** | **5** | **~10%** |
+| Phase | Layer | Required | Optional | Done | Progress |
+|-------|-------|----------|----------|------|----------|
+| Phase 1 | Layer 0 | 5 | 0 | 5 | ✅ 100% |
+| Phase 2 | Layer 1 | 3 | 9 | 12 | ✅ 100% |
+| Phase 3 | Layer 2-3 | 8 | 1 | 9 | ✅ 100% |
+| Phase 4 | Layer 4 | 8 | 2 | 0 | 📋 0% |
+| Phase 5 | Layer 5 | 6 | 1 | 0 | 📋 0% |
+| Phase 6 | Layer 6 | 18 | 2 | 0 | 📋 0% |
+| **Total** | | **48** | **15** | **26** | **~41%** |
+
+### Test Progression
+
+| Phase | New Tests | Cumulative | Test Files |
+|-------|-----------|------------|------------|
+| Phase 1 | 0 | 0 | 0 |
+| Phase 2 | 16 | 16 | 3 |
+| Phase 3 | 45 | 61 | 7 |
 
 ## Related Pages
 
 - [Clean Architecture](../01-Architecture/Clean-Architecture) — Layer definitions
 - [Test Coverage Matrix](../06-Testing/Test-Coverage-Matrix) — Test status per requirement
 - [Getting Started](Getting-Started) — How to run and test
+- [Git Flow](Git-Flow) — Branch strategy dan release process

--- a/docs/wiki/membership-benefit-card/09-Phase-Reports/Phase-1-Report.md
+++ b/docs/wiki/membership-benefit-card/09-Phase-Reports/Phase-1-Report.md
@@ -1,0 +1,120 @@
+# Laporan Fase 1: Layer 0 — Data Models & Protocols
+
+> Tanggal selesai: April 2026
+> Status: ✅ Complete
+> Milestone: [Phase 1: Layer 0 - Foundation](https://github.com/widdestoyud/assesment-s1-2026/milestone/1) (Closed)
+> Issues: #31, #32, #33 (All closed)
+
+---
+
+## Ringkasan
+
+Fase 1 membangun fondasi seluruh proyek MBC: tipe data domain, validation schemas, konstanta konfigurasi, helper utilities, dan protocol interfaces. Semua modul di layer ini adalah **pure types tanpa runtime dependency** — menjadi "bricks" dasar yang digunakan oleh semua layer di atasnya.
+
+Tidak ada test di fase ini karena seluruh output adalah type definitions dan interfaces yang divalidasi oleh TypeScript compiler.
+
+---
+
+## Scope Pekerjaan
+
+| Task | Deskripsi | Status |
+|------|-----------|--------|
+| 1.1 | MBC constants dan storage keys | ✅ Done |
+| 1.2 | Data model interfaces dan Zod schemas | ✅ Done |
+| 1.3 | MBC helper utilities (formatIDR, formatDuration) | ✅ Done |
+| 2.1 | NfcProtocol interface | ✅ Done |
+| 2.2 | ~~IndexedDbProtocol~~ (Dihapus — disederhanakan ke localStorage) | ✅ Done |
+
+---
+
+## Deliverables
+
+### Files Created
+
+| File | Layer | Fungsi |
+|------|-------|--------|
+| `src/utils/constants/mbc-keys.ts` | 0 | Storage keys (`MBC_DEVICE_ID`, `MBC_SERVICE_REGISTRY`), Silent Shield config (algorithm, passphrase, salt, iterations, key/IV/tag lengths) |
+| `src/@core/services/mbc/models/card-data.model.ts` | 0 | `CardData`, `MemberIdentity`, `CheckInStatus`, `TransactionLogEntry` interfaces |
+| `src/@core/services/mbc/models/service-type.model.ts` | 0 | `ServiceType`, `PricingStrategy` interfaces, `DEFAULT_PARKING_SERVICE` constant |
+| `src/@core/services/mbc/models/common.model.ts` | 0 | `RoleMode`, `NfcStatus`, `NfcError`, `FeeResult`, `CheckInResult`, `CheckOutResult`, `OperationResult`, `AtomicWriteResult`, `WriteVerifyResult`, `StorageError`, `NfcCapabilityStatus` |
+| `src/@core/services/mbc/models/schemas.ts` | 0 | Zod schemas: `CardDataSchema`, `ServiceTypeFormSchema`, `RegistrationFormSchema`, `TopUpFormSchema`, `ManualCalcFormSchema` |
+| `src/@core/services/mbc/models/index.ts` | 0 | Barrel export untuk semua models |
+| `src/utils/helpers/mbc.helper.ts` | 0 | `formatIDR()` — format angka ke Rupiah, `formatDuration()` — format durasi ke jam/menit |
+| `src/@core/protocols/nfc/index.ts` | 0 | `NfcProtocol` interface: `isSupported()`, `requestPermission()`, `startScan()`, `write()` |
+| `src/@core/protocols/key-value-store/index.ts` | 0 | `KeyValueStoreProtocol` interface: `get<T>()`, `set<T>()`, `delete()`, `getAll<T>()`, `isAvailable()` |
+
+### Data Model Overview
+
+```mermaid
+classDiagram
+    class CardData {
+        +number version
+        +MemberIdentity member
+        +number balance
+        +CheckInStatus|null checkIn
+        +TransactionLogEntry[] transactions
+    }
+    class MemberIdentity {
+        +string name
+        +string memberId
+    }
+    class CheckInStatus {
+        +string timestamp
+        +string serviceTypeId
+        +string deviceId
+    }
+    class TransactionLogEntry {
+        +number amount
+        +string timestamp
+        +string activityType
+        +string serviceTypeId
+    }
+    class ServiceType {
+        +string id
+        +string displayName
+        +string activityType
+        +PricingStrategy pricing
+    }
+    class PricingStrategy {
+        +number ratePerUnit
+        +string unitType
+        +string roundingStrategy
+    }
+
+    CardData --> MemberIdentity
+    CardData --> CheckInStatus
+    CardData --> TransactionLogEntry
+    ServiceType --> PricingStrategy
+```
+
+---
+
+## Keputusan Arsitektur
+
+| Keputusan | Alasan |
+|-----------|--------|
+| **IndexedDB dihapus** → localStorage only | Data yang perlu di-persist hanya Device_ID dan Service Registry (kecil). IndexedDB overkill untuk use case ini. |
+| **Zod untuk semua validasi** | Runtime validation untuk data dari NFC card dan localStorage. Compile-time types saja tidak cukup untuk data eksternal. |
+| **Barrel exports via index.ts** | Clean imports: `import { CardData, FeeResult } from '@core/services/mbc/models'` |
+| **Constants as const** | Type-safe constant values dengan `as const` untuk compile-time checking |
+
+---
+
+## Requirements Covered
+
+| Requirement | Deskripsi | Modul |
+|-------------|-----------|-------|
+| Req 1.1 | Role mode types | common.model.ts |
+| Req 2.1, 2.2, 2.4, 3.1 | NFC protocol interface | nfc/index.ts |
+| Req 8.9, 9.3 | IDR formatting, duration formatting | mbc.helper.ts |
+| Req 12.2-3 | Pricing strategy types | service-type.model.ts |
+| Req 13.1 | Card data schema definition | card-data.model.ts, schemas.ts |
+| Req 15.2 | Service type form schema | schemas.ts |
+| Req 19.1, 19.6, 20.1 | Storage keys, device ID key | mbc-keys.ts |
+
+---
+
+## Catatan
+
+- Fase ini tidak menghasilkan test karena semua output adalah type definitions. Validasi dilakukan oleh TypeScript compiler (`tsc --noEmit`).
+- `KeyValueStoreProtocol` sudah ada sebelumnya di proyek, di-refactor dari `src/@core/protocols/storage/` ke `src/@core/protocols/key-value-store/` untuk konsistensi naming.

--- a/docs/wiki/membership-benefit-card/09-Phase-Reports/Phase-2-Report.md
+++ b/docs/wiki/membership-benefit-card/09-Phase-Reports/Phase-2-Report.md
@@ -1,0 +1,157 @@
+# Laporan Fase 2: Layer 1 — Pure Logic Services
+
+> Tanggal selesai: April 2026
+> Status: ✅ Complete
+> Milestone: [Phase 2: Layer 1 - Pure Logic Services](https://github.com/widdestoyud/assesment-s1-2026/milestone/2) (Closed)
+> Issues: #1 – #6 (All closed)
+
+---
+
+## Ringkasan
+
+Fase 2 mengimplementasikan 3 pure logic services yang menjadi inti bisnis MBC:
+
+1. **pricing.service** — Kalkulasi tarif berdasarkan pricing strategy (per-hour, per-visit, flat-fee)
+2. **card-data.service** — Serialisasi, deserialisasi, validasi, dan mutasi data kartu NFC
+3. **silent-shield.service** — Enkripsi/dekripsi data kartu dengan AES-256-GCM
+
+Semua service di layer ini adalah **stateless pure functions** — tidak ada I/O, tidak ada side effects, tidak ada dependency ke browser API. Ini memungkinkan testing yang cepat, reliable, dan reproducible.
+
+Fase ini juga menghasilkan **property-based tests** menggunakan fast-check yang memvalidasi 9 correctness properties formal.
+
+---
+
+## Scope Pekerjaan
+
+| Task | Deskripsi | Status |
+|------|-----------|--------|
+| 3.1 | pricing.service — kalkulasi tarif per service type | ✅ Done |
+| 3.2* | Property tests: Ceiling Rounding (P8) | ✅ Done |
+| 3.3* | Property tests: Pricing Consistency (P9) | ✅ Done |
+| 3.4 | card-data.service — serialize/deserialize/mutate CardData | ✅ Done |
+| 3.5* | Property tests: Serialization Round-Trip (P1) | ✅ Done |
+| 3.6* | Property tests: Balance Conservation Top-Up (P3) | ✅ Done |
+| 3.7* | Property tests: Balance Conservation Check-Out (P4) | ✅ Done |
+| 3.8* | Property tests: Exactly-Once Deduction (P5) | ✅ Done |
+| 3.9* | Property tests: Check-In Exclusivity (P6) | ✅ Done |
+| 3.10* | Property tests: Transaction Log Bounded (P7) | ✅ Done |
+| 3.11 | silent-shield.service — AES-256-GCM encrypt/decrypt | ✅ Done |
+| 3.12* | Property tests: Encryption Round-Trip (P2) | ✅ Done |
+
+---
+
+## Deliverables
+
+### Source Files
+
+| File | Fungsi | Interface |
+|------|--------|-----------|
+| `src/@core/services/mbc/pricing.service.ts` | Kalkulasi tarif | `PricingServiceInterface { calculateFee(strategy, checkInTime, checkOutTime): FeeResult }` |
+| `src/@core/services/mbc/card-data.service.ts` | Operasi data kartu | `CardDataServiceInterface { serialize, deserialize, validate, applyRegistration, applyTopUp, applyCheckIn, applyCheckOut, appendTransactionLog }` |
+| `src/@core/services/mbc/silent-shield.service.ts` | Enkripsi/dekripsi | `SilentShieldServiceInterface { encrypt(data): Uint8Array, decrypt(data): Uint8Array }` |
+
+### Test Files
+
+| File | Tests | Technique |
+|------|-------|-----------|
+| `src/@core/services/__tests__/mbc/pricing.service.test.ts` | 6 | fast-check property-based |
+| `src/@core/services/__tests__/mbc/card-data.service.test.ts` | 9 | fast-check property-based |
+| `src/@core/services/__tests__/mbc/silent-shield.service.test.ts` | 1 | fast-check property-based |
+
+**Total: 16 tests, semua passing**
+
+---
+
+## Detail Implementasi
+
+### pricing.service
+
+Menghitung tarif berdasarkan `PricingStrategy` yang dikonfigurasi per `ServiceType`.
+
+| Unit Type | Formula | Contoh |
+|-----------|---------|--------|
+| `per-hour` | `rounding(hours) × ratePerUnit` | Parkir 2.5 jam × Rp 2.000 = Rp 6.000 (ceiling) |
+| `per-visit` | `ratePerUnit` (fixed per kunjungan) | Restoran = Rp 15.000 per visit |
+| `flat-fee` | `ratePerUnit` (fixed regardless of duration) | VIP Lounge = Rp 50.000 |
+
+Rounding strategies: `ceiling` (bulatkan ke atas), `floor` (bulatkan ke bawah), `nearest` (bulatkan ke terdekat).
+
+### card-data.service
+
+Mengelola lifecycle data kartu NFC melalui pure mutation functions:
+
+```mermaid
+flowchart LR
+    A[CardData] --> |serialize| B[Uint8Array / JSON]
+    B --> |deserialize + Zod validate| A
+    A --> |applyRegistration| C[CardData with member]
+    C --> |applyTopUp| D[CardData with balance+]
+    D --> |applyCheckIn| E[CardData with checkIn]
+    E --> |applyCheckOut| F[CardData with balance- and checkIn cleared]
+```
+
+**Invariants yang dijaga:**
+- `transactions.length <= 5` (FIFO, oldest removed)
+- `applyCheckIn` throws jika sudah checked-in
+- `applyCheckOut` throws jika belum checked-in
+- Semua mutation mengembalikan objek baru (immutable)
+
+### silent-shield.service
+
+Enkripsi AES-256-GCM untuk melindungi data kartu dari pembacaan oleh NFC reader pihak ketiga.
+
+```
+Encrypt: plaintext → [IV (12B) | ciphertext | authTag (16B)]
+Decrypt: [IV (12B) | ciphertext | authTag (16B)] → plaintext
+```
+
+- Key derivation: PBKDF2 (100.000 iterasi, SHA-256)
+- IV: 12 bytes random per operasi write
+- Auth tag: 16 bytes untuk integrity verification
+- Key di-cache setelah derivasi pertama untuk performa
+
+---
+
+## Correctness Properties (Property-Based Tests)
+
+| # | Property | Formula | Service |
+|---|----------|---------|---------|
+| P1 | Serialization Round-Trip | `deserialize(serialize(card)) === card` | card-data |
+| P2 | Encryption Round-Trip | `decrypt(encrypt(data)) === data` | silent-shield |
+| P3 | Balance Conservation (Top-Up) | `applyTopUp(card, a).balance === card.balance + a` | card-data |
+| P4 | Balance Conservation (Check-Out) | `applyCheckOut(card, f).balance === card.balance - f` | card-data |
+| P5 | Exactly-Once Deduction | `applyCheckOut` on already checked-out card → throws | card-data |
+| P6 | Check-In Exclusivity | Checked-in card cannot check-in again | card-data |
+| P7 | Transaction Log Bounded | `transactions.length <= 5` after any operation | card-data |
+| P8 | Ceiling Rounding | `fee === Math.ceil(hours) × rate` for per-hour ceiling | pricing |
+| P9 | Pricing Consistency | Per-visit/flat-fee: `fee === ratePerUnit` regardless of duration | pricing |
+
+Semua property divalidasi dengan **fast-check** menggunakan arbitrary data generators untuk CardData, PricingStrategy, timestamps, dan amounts.
+
+---
+
+## Keputusan Arsitektur
+
+| Keputusan | Alasan |
+|-----------|--------|
+| **Factory function pattern** | `(deps: AwilixRegistry) => Interface` — bukan class. Memudahkan DI, testing, dan tree-shaking. |
+| **Immutability** | Semua mutation functions mengembalikan objek baru. Tidak pernah mutate input parameter. Mencegah side effects. |
+| **crypto-browserify** | Sudah ada sebagai polyfill di proyek. Menyediakan AES-256-GCM yang compatible dengan Node.js crypto API. |
+| **PBKDF2 key derivation** | 100.000 iterasi untuk brute-force resistance. Key di-cache di closure untuk performa. |
+| **JSON serialization** | Dipilih over binary format untuk debuggability. Masih muat dalam NFC tag memory (NTAG215: 504B, NTAG216: 888B). |
+| **Transaction log FIFO** | Max 5 entries, oldest removed first. Menjaga ukuran data kartu tetap bounded. |
+
+---
+
+## Requirements Covered
+
+| Requirement | Deskripsi | Service |
+|-------------|-----------|---------|
+| Req 5.2 | Top-up menambah balance | card-data.service |
+| Req 6.2, 6.3 | Check-in recording, double check-in prevention | card-data.service |
+| Req 8.6, 8.8 | Fee deduction, double check-out prevention | card-data.service |
+| Req 10.1, 10.2 | Transaction log append, max 5 entries | card-data.service |
+| Req 11.1-4 | Encrypt/decrypt, round-trip property | silent-shield.service |
+| Req 12.1-7 | Fee calculation, pricing strategies, default parking | pricing.service |
+| Req 13.1-5 | Card data schema, serialize/deserialize, round-trip | card-data.service |
+| Req 18.7 | Exactly-once deduction | card-data.service |

--- a/docs/wiki/membership-benefit-card/09-Phase-Reports/Phase-3-Report.md
+++ b/docs/wiki/membership-benefit-card/09-Phase-Reports/Phase-3-Report.md
@@ -1,0 +1,361 @@
+# Laporan Fase 3: Layer 2-3 — I/O Adapters & Stateful Services
+
+> Tanggal selesai: April 30, 2026
+> Status: ✅ Complete
+> Milestone: [Phase 3: Layer 2-3 - Adapters & Stateful Services](https://github.com/widdestoyud/assesment-s1-2026/milestone/3)
+> Issues: #7 – #14
+> Branch: `feat/mbc-phase-3-adapters-services`
+
+---
+
+## Ringkasan
+
+Fase 3 membangun dua layer sekaligus:
+
+- **Layer 2 (I/O Adapters)** — Adapter untuk browser API (Web NFC) yang mengimplementasikan protocol interfaces dari Layer 0
+- **Layer 3 (Stateful Services)** — Services yang mengkomposisi pure logic dari Layer 1 dengan I/O adapters, mengelola state via dependency injection
+
+Fase ini juga menyelesaikan **DI wiring** — mendaftarkan semua MBC protocols dan services ke Awilix container sehingga siap digunakan oleh use cases di fase 4.
+
+**Highlight:** 45 unit tests baru yang mencakup positive cases, negative cases, dan edge cases untuk setiap service.
+
+---
+
+## Scope Pekerjaan
+
+| Task | Deskripsi | Layer | Status |
+|------|-----------|-------|--------|
+| 5.1 | webNfcAdapter — NDEFReader wrapper | Layer 2 | ✅ Done |
+| 6.1 | nfc.service — readCard, writeCard, writeAndVerify | Layer 3 | ✅ Done |
+| 6.2 | storage-health.service — isAvailable, checkWriteCapacity | Layer 3 | ✅ Done |
+| 6.3 | device.service — getDeviceId, ensureDeviceId | Layer 3 | ✅ Done |
+| 6.4 | service-registry.service — CRUD + initializeDefaults | Layer 3 | ✅ Done |
+| 6.5* | Unit tests untuk semua stateful services | Test | ✅ Done |
+| 7.1 | MBC protocol DI container | DI | ✅ Done |
+| 7.2 | MBC service DI container (7 services) | DI | ✅ Done |
+| 7.3 | Wire MBC containers ke root container | DI | ✅ Done |
+
+---
+
+## Deliverables
+
+### Layer 2 — I/O Adapter
+
+| File | Fungsi |
+|------|--------|
+| `src/infrastructure/nfc/webNfcAdapter.ts` | Wraps browser `NDEFReader` API behind `NfcProtocol` interface. Handles scan, write, permission request. Encodes data sebagai base64 NDEF text records. Maps semua Web NFC error types ke typed `NfcError`. |
+| `types/web-nfc.d.ts` | TypeScript type declarations untuk Web NFC API (`NDEFReader`, `NDEFMessage`, `NDEFRecord`, `NDEFReadingEvent`) |
+
+### Layer 3 — Stateful Services
+
+| File | Interface | Dependencies (via DI) |
+|------|-----------|----------------------|
+| `src/@core/services/mbc/nfc.service.ts` | `NfcServiceInterface` | `nfcProtocol: NfcProtocol` |
+| `src/@core/services/mbc/storage-health.service.ts` | `StorageHealthServiceInterface` | `keyValueStore: KeyValueStoreProtocol` |
+| `src/@core/services/mbc/device.service.ts` | `DeviceServiceInterface` | `keyValueStore: KeyValueStoreProtocol` |
+| `src/@core/services/mbc/service-registry.service.ts` | `ServiceRegistryServiceInterface` | `keyValueStore: KeyValueStoreProtocol` |
+
+### DI Wiring
+
+| File | Fungsi |
+|------|--------|
+| `src/infrastructure/di/registry/mbcProtocolContainer.ts` | Register `nfcProtocol` → `webNfcAdapter` via `asValue()` |
+| `src/infrastructure/di/registry/mbcServiceContainer.ts` | Register 7 MBC services: 3 stateless (`asFunction`) + 4 singleton (`asFunction().singleton()`) |
+| `src/infrastructure/di/container.ts` (modified) | Import dan call `registerMbcProtocolModules`, `registerMbcServiceModules`. Update `AwilixRegistry` type union. |
+
+### Test Files
+
+| File | Tests |
+|------|-------|
+| `src/@core/services/__tests__/mbc/nfc.service.test.ts` | 14 |
+| `src/@core/services/__tests__/mbc/storage-health.service.test.ts` | 8 |
+| `src/@core/services/__tests__/mbc/device.service.test.ts` | 6 |
+| `src/@core/services/__tests__/mbc/service-registry.service.test.ts` | 17 |
+
+**Total fase 3: 45 tests baru**
+**Total kumulatif: 61 tests (16 fase 2 + 45 fase 3), 7 test files**
+
+---
+
+## Detail Implementasi
+
+### 5.1 — webNfcAdapter
+
+Adapter yang membungkus browser Web NFC API (`NDEFReader`) di balik `NfcProtocol` interface.
+
+**Encoding strategy:** Card data (Uint8Array) di-encode ke base64 string, lalu ditulis sebagai NDEF text record. Saat membaca, base64 di-decode kembali ke Uint8Array.
+
+```mermaid
+flowchart LR
+    A[Uint8Array] --> |uint8ArrayToBase64| B[Base64 String]
+    B --> |NDEF Text Record| C[NFC Tag]
+    C --> |Read NDEF| D[Base64 String]
+    D --> |base64ToUint8Array| E[Uint8Array]
+```
+
+**Error mapping:**
+
+| DOMException | NfcError Type |
+|-------------|---------------|
+| `NotAllowedError` | `permission_denied` |
+| `NotSupportedError` | `hardware_unavailable` |
+| `NetworkError` | `connection_lost` |
+| Other | `read_failed` / `write_failed` |
+
+### 6.1 — nfc.service
+
+High-level NFC operations yang digunakan oleh use cases.
+
+| Method | Behavior |
+|--------|----------|
+| `isAvailable()` | Delegates ke `nfcProtocol.isSupported()` |
+| `requestPermission()` | Delegates ke `nfcProtocol.requestPermission()` |
+| `readCard()` | One-shot: start scan → resolve pada first read → abort session |
+| `writeCard(data)` | Delegates ke `nfcProtocol.write(data)` |
+| `writeAndVerify(data)` | Write → readCard() → byte-level compare → return `WriteVerifyResult` |
+
+**One-shot pattern:** `readCard()` mengembalikan Promise yang resolve pada pembacaan pertama, lalu otomatis abort scan session. Ini mencegah multiple reads yang tidak diinginkan.
+
+### 6.2 — storage-health.service
+
+Mendeteksi ketersediaan dan kapasitas localStorage.
+
+```mermaid
+flowchart TD
+    A[checkWriteCapacity] --> B{isAvailable?}
+    B -->|No| C[Return: unavailable]
+    B -->|Yes| D[Test write: set test key]
+    D --> E{Write success?}
+    E -->|QuotaExceededError| F[Return: quota_exceeded]
+    E -->|Other error| G[Return: write_failed]
+    E -->|Yes| H[Read back test key]
+    H --> I{Match?}
+    I -->|No| J[Return: write_failed - mismatch]
+    I -->|Yes| K[Delete test key]
+    K --> L[Return: canWrite true]
+```
+
+**Cross-browser QuotaExceededError detection:** Mendeteksi `DOMException.name === 'QuotaExceededError'` (Chrome/Firefox/Edge) dan `DOMException.code === 22` (Safari legacy).
+
+### 6.3 — device.service
+
+Mengelola Device_ID lifecycle untuk device binding.
+
+| Method | Behavior |
+|--------|----------|
+| `getDeviceId()` | Read dari localStorage. Return `undefined` jika tidak ada. |
+| `ensureDeviceId()` | Get existing atau generate baru via `crypto.randomUUID()`. Return `{ deviceId, wasRegenerated }`. |
+
+**`wasRegenerated` flag:** Digunakan oleh UI untuk menampilkan warning bahwa check-in sessions dari device ID lama tidak bisa di-checkout di device ini.
+
+### 6.4 — service-registry.service
+
+CRUD untuk konfigurasi Service Type yang di-persist di localStorage.
+
+| Method | Behavior |
+|--------|----------|
+| `getAll()` | Read registry, validate setiap entry dengan Zod, filter corrupted entries |
+| `getById(id)` | Find by ID dari registry |
+| `add(serviceType)` | Validate → check duplicate ID → append → persist |
+| `update(id, updates)` | Find → merge updates (preserve ID) → validate result → persist |
+| `remove(id)` | Find → splice → persist |
+| `initializeDefaults()` | Jika registry kosong, seed dengan `DEFAULT_PARKING_SERVICE` |
+
+**Defensive reading:** Setiap entry divalidasi dengan `ServiceTypeFormSchema.safeParse()` saat dibaca. Entries yang corrupted di-filter out tanpa crash.
+
+### 7.1-7.3 — DI Wiring
+
+```mermaid
+graph TB
+    subgraph "Root Container (container.ts)"
+        direction TB
+        PC[protocolContainer<br/>keyValueStore]
+        MPC[mbcProtocolContainer<br/>nfcProtocol]
+        SC[serviceContainer]
+        MSC[mbcServiceContainer<br/>7 MBC services]
+        TC[tanstackContainer]
+        UC[useCaseContainer]
+        LC[libraryContainer]
+        CC[controllerContainer]
+        RC[reactContainer]
+        HC[helperContainer]
+    end
+
+    subgraph "MBC Services (mbcServiceContainer)"
+        PS[pricingService]
+        CDS[cardDataService]
+        SSS[silentShieldService]
+        NS[nfcService ★]
+        DS[deviceService ★]
+        SHS[storageHealthService ★]
+        SRS[serviceRegistryService ★]
+    end
+
+    MSC --> PS
+    MSC --> CDS
+    MSC --> SSS
+    MSC --> NS
+    MSC --> DS
+    MSC --> SHS
+    MSC --> SRS
+```
+
+★ = registered as singleton
+
+**AwilixRegistry type** sekarang mencakup `MbcProtocolContainerInterface` dan `MbcServiceContainerInterface`, sehingga semua MBC services accessible via typed DI.
+
+---
+
+## Test Report
+
+### Ringkasan
+
+| Metric | Value |
+|--------|-------|
+| Test files baru | 4 |
+| Tests baru | 45 |
+| Tests kumulatif | 61 |
+| Test files kumulatif | 7 |
+| Execution time | ~1.3s |
+| Status | ✅ All passing |
+
+### Test Scenarios per Service
+
+#### nfc.service — 14 tests
+
+| # | Scenario | Category | Type |
+|---|----------|----------|------|
+| 1 | isAvailable returns true when supported | ✅ Positive | Unit |
+| 2 | isAvailable returns false when unsupported | ❌ Negative | Unit |
+| 3 | requestPermission returns granted | ✅ Positive | Unit |
+| 4 | requestPermission returns denied | ❌ Negative | Unit |
+| 5 | requestPermission returns unsupported | ❌ Negative | Unit |
+| 6 | readCard resolves with data from first scan | ✅ Positive | Async |
+| 7 | readCard rejects on NFC error | ❌ Negative | Async |
+| 8 | writeCard delegates to protocol | ✅ Positive | Unit |
+| 9 | writeCard propagates errors | ❌ Negative | Async |
+| 10 | writeAndVerify succeeds when data matches | ✅ Positive | Async |
+| 11 | writeAndVerify fails on data mismatch | ❌ Negative | Async |
+| 12 | writeAndVerify fails on write error | ❌ Negative | Async |
+| 13 | writeAndVerify fails on verification read error | ❌ Negative | Async |
+| 14 | writeAndVerify handles empty data arrays | 🔶 Edge | Async |
+
+#### storage-health.service — 8 tests
+
+| # | Scenario | Category | Type |
+|---|----------|----------|------|
+| 1 | isAvailable returns true | ✅ Positive | Unit |
+| 2 | isAvailable returns false | ❌ Negative | Unit |
+| 3 | checkWriteCapacity returns canWrite: true | ✅ Positive | Unit |
+| 4 | unavailable error when storage not accessible | ❌ Negative | Unit |
+| 5 | write_failed when read-back mismatch | 🔶 Edge | Unit |
+| 6 | quota_exceeded on QuotaExceededError | ❌ Negative | Unit |
+| 7 | write_failed on generic error | ❌ Negative | Unit |
+| 8 | cleanup test key after successful check | 🔶 Edge | Unit |
+
+#### device.service — 6 tests
+
+| # | Scenario | Category | Type |
+|---|----------|----------|------|
+| 1 | getDeviceId returns stored ID | ✅ Positive | Unit |
+| 2 | getDeviceId returns undefined when not stored | ❌ Negative | Unit |
+| 3 | ensureDeviceId returns existing without regeneration | ✅ Positive | Unit |
+| 4 | ensureDeviceId generates new ID when missing | ✅ Positive | Unit |
+| 5 | ensureDeviceId is idempotent (wasRegenerated false on 2nd call) | 🔶 Edge | Unit |
+| 6 | ensureDeviceId propagates storage write errors | ❌ Negative | Unit |
+
+#### service-registry.service — 17 tests
+
+| # | Scenario | Category | Type |
+|---|----------|----------|------|
+| 1 | initializeDefaults creates parking service when empty | ✅ Positive | Unit |
+| 2 | initializeDefaults skips when registry exists | ❌ Negative | Unit |
+| 3 | getAll returns all service types | ✅ Positive | Unit |
+| 4 | getAll returns empty when no registry | ❌ Negative | Unit |
+| 5 | getAll filters corrupted entries | 🔶 Edge | Unit |
+| 6 | getById returns found service | ✅ Positive | Unit |
+| 7 | getById returns undefined when not found | ❌ Negative | Unit |
+| 8 | add valid service type | ✅ Positive | Unit |
+| 9 | add throws on duplicate ID | ❌ Negative | Unit |
+| 10 | add throws on invalid data | ❌ Negative | Unit |
+| 11 | update existing service type | ✅ Positive | Unit |
+| 12 | update throws when not found | ❌ Negative | Unit |
+| 13 | update preserves original ID | 🔶 Edge | Unit |
+| 14 | update throws on invalid result | ❌ Negative | Unit |
+| 15 | remove existing service type | ✅ Positive | Unit |
+| 16 | remove throws when not found | ❌ Negative | Unit |
+| 17 | remove last item leaves empty registry | 🔶 Edge | Unit |
+
+### Test Distribution
+
+```mermaid
+pie title Test Categories (45 tests)
+    "Positive Cases" : 17
+    "Negative Cases" : 20
+    "Edge Cases" : 8
+```
+
+---
+
+## Dependency Graph
+
+```mermaid
+graph TB
+    subgraph "Layer 2 — I/O Adapters"
+        WNA[webNfcAdapter]
+        WSA[webStorageAdapter<br/>existing]
+    end
+
+    subgraph "Layer 3 — Stateful Services"
+        NS[nfc.service]
+        DS[device.service]
+        SHS[storage-health.service]
+        SRS[service-registry.service]
+    end
+
+    subgraph "Layer 1 — Pure Logic"
+        PS[pricing.service]
+        CDS[card-data.service]
+        SSS[silent-shield.service]
+    end
+
+    subgraph "Protocols"
+        NP[NfcProtocol]
+        KVP[KeyValueStoreProtocol]
+    end
+
+    WNA -.implements.-> NP
+    WSA -.implements.-> KVP
+    NS --> NP
+    DS --> KVP
+    SHS --> KVP
+    SRS --> KVP
+```
+
+---
+
+## Keputusan Arsitektur
+
+| Keputusan | Alasan |
+|-----------|--------|
+| **Base64 encoding untuk NFC** | NDEF text record hanya mendukung string. Base64 encoding memastikan binary data (encrypted card data) bisa disimpan sebagai text. |
+| **One-shot readCard pattern** | `readCard()` resolve pada first scan lalu abort. Mencegah multiple reads dan simplify Promise-based API untuk use cases. |
+| **Singleton untuk stateful services** | nfc, device, storage-health, service-registry di-register sebagai singleton karena mereka mengelola shared state atau cache. |
+| **Zod validation on read** | service-registry memvalidasi setiap entry saat membaca dari localStorage. Corrupted entries di-filter tanpa crash. Defensive programming. |
+| **QuotaExceededError cross-browser** | Deteksi via `DOMException.name` (modern) dan `DOMException.code` (Safari legacy). |
+| **crypto.randomUUID()** | Tersedia di semua browser modern. Menghasilkan UUID v4 yang cryptographically random untuk Device_ID. |
+| **Pick<AwilixRegistry, ...> untuk deps** | Services hanya menerima dependencies yang mereka butuhkan, bukan seluruh registry. Explicit dependency declaration. |
+
+---
+
+## Requirements Covered
+
+| Requirement | Deskripsi | Service |
+|-------------|-----------|---------|
+| Req 2.1, 2.2, 2.4, 3.1 | NFC read/write/permission | webNfcAdapter, nfc.service |
+| Req 3.4, 3.7 | Write verification | nfc.service |
+| Req 15.1-7 | Service type CRUD, defaults, persistence | service-registry.service |
+| Req 19.1, 19.6, 19.7 | Device_ID lifecycle, regeneration warning | device.service |
+| Req 20.2-4 | Storage availability, quota detection | storage-health.service |
+| Req 20.5-6 | Service registry validation, re-initialization | service-registry.service |
+| Req 20.8 | Graceful storage error handling | device.service, service-registry.service |

--- a/src/@core/services/__tests__/mbc/device.service.test.ts
+++ b/src/@core/services/__tests__/mbc/device.service.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { KeyValueStoreProtocol } from '@core/protocols/key-value-store';
+
+import { DeviceService } from '../../mbc/device.service';
+import { MBC_KEYS } from '@utils/constants/mbc-keys';
+
+const STORE_NAME = MBC_KEYS.MBC_STORE_NAME;
+const DEVICE_KEY = MBC_KEYS.MBC_DEVICE_ID;
+
+function createMockStore(
+  overrides: Partial<KeyValueStoreProtocol> = {},
+): KeyValueStoreProtocol {
+  return {
+    get: vi.fn().mockResolvedValue(undefined),
+    set: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
+    getAll: vi.fn().mockResolvedValue([]),
+    isAvailable: vi.fn().mockResolvedValue(true),
+    ...overrides,
+  };
+}
+
+// Mock crypto.randomUUID for deterministic tests
+const MOCK_UUID = '550e8400-e29b-41d4-a716-446655440000';
+
+describe('DeviceService', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(crypto, 'randomUUID').mockReturnValue(MOCK_UUID as `${string}-${string}-${string}-${string}-${string}`);
+  });
+
+  describe('getDeviceId', () => {
+    it('returns the stored device ID when it exists', async () => {
+      const existingId = 'existing-device-id-123';
+      const store = createMockStore({
+        get: vi.fn().mockResolvedValue(existingId),
+      });
+      const service = DeviceService({ keyValueStore: store });
+
+      const result = await service.getDeviceId();
+
+      expect(result).toBe(existingId);
+      expect(store.get).toHaveBeenCalledWith(STORE_NAME, DEVICE_KEY);
+    });
+
+    it('returns undefined when no device ID is stored', async () => {
+      const store = createMockStore({
+        get: vi.fn().mockResolvedValue(undefined),
+      });
+      const service = DeviceService({ keyValueStore: store });
+
+      const result = await service.getDeviceId();
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('ensureDeviceId', () => {
+    it('returns existing device ID without regeneration', async () => {
+      const existingId = 'existing-device-id-456';
+      const store = createMockStore({
+        get: vi.fn().mockResolvedValue(existingId),
+      });
+      const service = DeviceService({ keyValueStore: store });
+
+      const result = await service.ensureDeviceId();
+
+      expect(result.deviceId).toBe(existingId);
+      expect(result.wasRegenerated).toBe(false);
+      expect(store.set).not.toHaveBeenCalled();
+    });
+
+    it('generates and persists a new device ID when none exists', async () => {
+      const store = createMockStore({
+        get: vi.fn().mockResolvedValue(undefined),
+      });
+      const service = DeviceService({ keyValueStore: store });
+
+      const result = await service.ensureDeviceId();
+
+      expect(result.deviceId).toBe(MOCK_UUID);
+      expect(result.wasRegenerated).toBe(true);
+      expect(store.set).toHaveBeenCalledWith(STORE_NAME, DEVICE_KEY, MOCK_UUID);
+    });
+
+    it('flags wasRegenerated: true only on first generation', async () => {
+      let storedValue: string | undefined;
+      const store = createMockStore({
+        get: vi.fn().mockImplementation(() => Promise.resolve(storedValue)),
+        set: vi.fn().mockImplementation((_s: string, _k: string, v: string) => {
+          storedValue = v;
+          return Promise.resolve();
+        }),
+      });
+      const service = DeviceService({ keyValueStore: store });
+
+      // First call — generates new ID
+      const first = await service.ensureDeviceId();
+      expect(first.wasRegenerated).toBe(true);
+
+      // Second call — returns existing
+      const second = await service.ensureDeviceId();
+      expect(second.wasRegenerated).toBe(false);
+      expect(second.deviceId).toBe(MOCK_UUID);
+    });
+
+    it('propagates storage write errors', async () => {
+      const store = createMockStore({
+        get: vi.fn().mockResolvedValue(undefined),
+        set: vi.fn().mockRejectedValue(new Error('Storage write failed')),
+      });
+      const service = DeviceService({ keyValueStore: store });
+
+      await expect(service.ensureDeviceId()).rejects.toThrow('Storage write failed');
+    });
+  });
+});

--- a/src/@core/services/__tests__/mbc/nfc.service.test.ts
+++ b/src/@core/services/__tests__/mbc/nfc.service.test.ts
@@ -1,0 +1,235 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { NfcProtocol } from '@core/protocols/nfc';
+import type { NfcError, NfcScanSession } from '@core/services/mbc/models';
+
+import { NfcService } from '../../mbc/nfc.service';
+
+function createMockNfcProtocol(
+  overrides: Partial<NfcProtocol> = {},
+): NfcProtocol {
+  return {
+    isSupported: vi.fn().mockReturnValue(true),
+    requestPermission: vi.fn().mockResolvedValue('granted'),
+    startScan: vi.fn().mockReturnValue({ abort: vi.fn() }),
+    write: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe('NfcService', () => {
+  describe('isAvailable', () => {
+    it('returns true when NFC is supported', () => {
+      const protocol = createMockNfcProtocol({
+        isSupported: vi.fn().mockReturnValue(true),
+      });
+      const service = NfcService({ nfcProtocol: protocol });
+
+      expect(service.isAvailable()).toBe(true);
+    });
+
+    it('returns false when NFC is not supported', () => {
+      const protocol = createMockNfcProtocol({
+        isSupported: vi.fn().mockReturnValue(false),
+      });
+      const service = NfcService({ nfcProtocol: protocol });
+
+      expect(service.isAvailable()).toBe(false);
+    });
+  });
+
+  describe('requestPermission', () => {
+    it('delegates to protocol and returns granted', async () => {
+      const protocol = createMockNfcProtocol({
+        requestPermission: vi.fn().mockResolvedValue('granted'),
+      });
+      const service = NfcService({ nfcProtocol: protocol });
+
+      const result = await service.requestPermission();
+
+      expect(result).toBe('granted');
+      expect(protocol.requestPermission).toHaveBeenCalledOnce();
+    });
+
+    it('returns denied when permission is denied', async () => {
+      const protocol = createMockNfcProtocol({
+        requestPermission: vi.fn().mockResolvedValue('denied'),
+      });
+      const service = NfcService({ nfcProtocol: protocol });
+
+      const result = await service.requestPermission();
+
+      expect(result).toBe('denied');
+    });
+
+    it('returns unsupported when NFC is not available', async () => {
+      const protocol = createMockNfcProtocol({
+        requestPermission: vi.fn().mockResolvedValue('unsupported'),
+      });
+      const service = NfcService({ nfcProtocol: protocol });
+
+      const result = await service.requestPermission();
+
+      expect(result).toBe('unsupported');
+    });
+  });
+
+  describe('readCard', () => {
+    it('resolves with data from the first NFC read', async () => {
+      const testData = new Uint8Array([1, 2, 3, 4, 5]);
+      const mockAbort = vi.fn();
+
+      const protocol = createMockNfcProtocol({
+        startScan: vi.fn().mockImplementation(
+          (onRead: (data: Uint8Array) => void): NfcScanSession => {
+            // Simulate async NFC read
+            setTimeout(() => onRead(testData), 10);
+            return { abort: mockAbort };
+          },
+        ),
+      });
+      const service = NfcService({ nfcProtocol: protocol });
+
+      const result = await service.readCard();
+
+      expect(result).toEqual(testData);
+      expect(mockAbort).toHaveBeenCalledOnce();
+    });
+
+    it('rejects when NFC read fails', async () => {
+      const protocol = createMockNfcProtocol({
+        startScan: vi.fn().mockImplementation(
+          (_onRead: (data: Uint8Array) => void, onError: (err: NfcError) => void): NfcScanSession => {
+            setTimeout(() => onError({
+              type: 'read_failed',
+              message: 'Tag removed too quickly',
+            }), 10);
+            return { abort: vi.fn() };
+          },
+        ),
+      });
+      const service = NfcService({ nfcProtocol: protocol });
+
+      await expect(service.readCard()).rejects.toThrow('NFC read failed');
+    });
+  });
+
+  describe('writeCard', () => {
+    it('delegates write to protocol', async () => {
+      const testData = new Uint8Array([10, 20, 30]);
+      const protocol = createMockNfcProtocol();
+      const service = NfcService({ nfcProtocol: protocol });
+
+      await service.writeCard(testData);
+
+      expect(protocol.write).toHaveBeenCalledWith(testData);
+    });
+
+    it('propagates write errors', async () => {
+      const protocol = createMockNfcProtocol({
+        write: vi.fn().mockRejectedValue(new Error('Write failed')),
+      });
+      const service = NfcService({ nfcProtocol: protocol });
+
+      await expect(service.writeCard(new Uint8Array([1]))).rejects.toThrow(
+        'Write failed',
+      );
+    });
+  });
+
+  describe('writeAndVerify', () => {
+    it('returns success when written data matches read-back', async () => {
+      const testData = new Uint8Array([1, 2, 3]);
+
+      const protocol = createMockNfcProtocol({
+        write: vi.fn().mockResolvedValue(undefined),
+        startScan: vi.fn().mockImplementation(
+          (onRead: (data: Uint8Array) => void): NfcScanSession => {
+            // Return the same data that was written
+            setTimeout(() => onRead(new Uint8Array([1, 2, 3])), 10);
+            return { abort: vi.fn() };
+          },
+        ),
+      });
+      const service = NfcService({ nfcProtocol: protocol });
+
+      const result = await service.writeAndVerify(testData);
+
+      expect(result.success).toBe(true);
+      expect(result.error).toBeUndefined();
+    });
+
+    it('returns failure when read-back does not match', async () => {
+      const testData = new Uint8Array([1, 2, 3]);
+
+      const protocol = createMockNfcProtocol({
+        write: vi.fn().mockResolvedValue(undefined),
+        startScan: vi.fn().mockImplementation(
+          (onRead: (data: Uint8Array) => void): NfcScanSession => {
+            // Return different data
+            setTimeout(() => onRead(new Uint8Array([4, 5, 6])), 10);
+            return { abort: vi.fn() };
+          },
+        ),
+      });
+      const service = NfcService({ nfcProtocol: protocol });
+
+      const result = await service.writeAndVerify(testData);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Verification failed');
+    });
+
+    it('returns failure when write throws', async () => {
+      const protocol = createMockNfcProtocol({
+        write: vi.fn().mockRejectedValue(new Error('Connection lost')),
+      });
+      const service = NfcService({ nfcProtocol: protocol });
+
+      const result = await service.writeAndVerify(new Uint8Array([1]));
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Connection lost');
+    });
+
+    it('returns failure when verification read throws', async () => {
+      const protocol = createMockNfcProtocol({
+        write: vi.fn().mockResolvedValue(undefined),
+        startScan: vi.fn().mockImplementation(
+          (_onRead: (data: Uint8Array) => void, onError: (err: NfcError) => void): NfcScanSession => {
+            setTimeout(() => onError({
+              type: 'read_failed',
+              message: 'Tag removed during verification',
+            }), 10);
+            return { abort: vi.fn() };
+          },
+        ),
+      });
+      const service = NfcService({ nfcProtocol: protocol });
+
+      const result = await service.writeAndVerify(new Uint8Array([1, 2]));
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('NFC read failed');
+    });
+
+    it('handles empty data arrays', async () => {
+      const emptyData = new Uint8Array([]);
+
+      const protocol = createMockNfcProtocol({
+        write: vi.fn().mockResolvedValue(undefined),
+        startScan: vi.fn().mockImplementation(
+          (onRead: (data: Uint8Array) => void): NfcScanSession => {
+            setTimeout(() => onRead(new Uint8Array([])), 10);
+            return { abort: vi.fn() };
+          },
+        ),
+      });
+      const service = NfcService({ nfcProtocol: protocol });
+
+      const result = await service.writeAndVerify(emptyData);
+
+      expect(result.success).toBe(true);
+    });
+  });
+});

--- a/src/@core/services/__tests__/mbc/service-registry.service.test.ts
+++ b/src/@core/services/__tests__/mbc/service-registry.service.test.ts
@@ -1,0 +1,265 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { KeyValueStoreProtocol } from '@core/protocols/key-value-store';
+import type { ServiceType } from '@core/services/mbc/models';
+
+import { DEFAULT_PARKING_SERVICE } from '@core/services/mbc/models';
+import { ServiceRegistryService } from '../../mbc/service-registry.service';
+import { MBC_KEYS } from '@utils/constants/mbc-keys';
+
+const STORE_NAME = MBC_KEYS.MBC_STORE_NAME;
+const REGISTRY_KEY = MBC_KEYS.MBC_SERVICE_REGISTRY;
+
+const BIKE_RENTAL: ServiceType = {
+  id: 'bike-rental',
+  displayName: 'Sewa Sepeda',
+  activityType: 'bike-rental',
+  pricing: {
+    ratePerUnit: 5000,
+    unitType: 'per-hour',
+    roundingStrategy: 'ceiling',
+  },
+};
+
+const GYM_SESSION: ServiceType = {
+  id: 'gym-session',
+  displayName: 'Gym Session',
+  activityType: 'gym-session',
+  pricing: {
+    ratePerUnit: 15000,
+    unitType: 'per-visit',
+    roundingStrategy: 'ceiling',
+  },
+};
+
+function createMockStore(
+  initialData: ServiceType[] = [],
+): KeyValueStoreProtocol {
+  let stored: ServiceType[] = [...initialData];
+
+  return {
+    get: vi.fn().mockImplementation((_s: string, _k: string) =>
+      Promise.resolve(stored.length > 0 ? stored : undefined),
+    ),
+    set: vi.fn().mockImplementation((_s: string, _k: string, value: ServiceType[]) => {
+      stored = [...value];
+      return Promise.resolve();
+    }),
+    delete: vi.fn().mockResolvedValue(undefined),
+    getAll: vi.fn().mockResolvedValue([]),
+    isAvailable: vi.fn().mockResolvedValue(true),
+  };
+}
+
+describe('ServiceRegistryService', () => {
+  describe('initializeDefaults', () => {
+    it('creates default parking service when registry is empty', async () => {
+      const store = createMockStore([]);
+      const service = ServiceRegistryService({ keyValueStore: store });
+
+      await service.initializeDefaults();
+
+      expect(store.set).toHaveBeenCalledWith(
+        STORE_NAME,
+        REGISTRY_KEY,
+        [DEFAULT_PARKING_SERVICE],
+      );
+    });
+
+    it('does not overwrite existing registry', async () => {
+      const store = createMockStore([BIKE_RENTAL]);
+      const service = ServiceRegistryService({ keyValueStore: store });
+
+      await service.initializeDefaults();
+
+      expect(store.set).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getAll', () => {
+    it('returns all registered service types', async () => {
+      const store = createMockStore([DEFAULT_PARKING_SERVICE, BIKE_RENTAL]);
+      const service = ServiceRegistryService({ keyValueStore: store });
+
+      const result = await service.getAll();
+
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe('parking');
+      expect(result[1].id).toBe('bike-rental');
+    });
+
+    it('returns empty array when registry is empty', async () => {
+      const store = createMockStore([]);
+      const service = ServiceRegistryService({ keyValueStore: store });
+
+      const result = await service.getAll();
+
+      expect(result).toEqual([]);
+    });
+
+    it('filters out corrupted entries', async () => {
+      const corruptedEntry = { id: '', displayName: '' } as unknown as ServiceType;
+      const store = createMockStore([DEFAULT_PARKING_SERVICE, corruptedEntry]);
+      const service = ServiceRegistryService({ keyValueStore: store });
+
+      const result = await service.getAll();
+
+      // Only the valid parking service should remain
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('parking');
+    });
+  });
+
+  describe('getById', () => {
+    it('returns the service type when found', async () => {
+      const store = createMockStore([DEFAULT_PARKING_SERVICE, BIKE_RENTAL]);
+      const service = ServiceRegistryService({ keyValueStore: store });
+
+      const result = await service.getById('bike-rental');
+
+      expect(result).toBeDefined();
+      expect(result?.id).toBe('bike-rental');
+      expect(result?.displayName).toBe('Sewa Sepeda');
+    });
+
+    it('returns undefined when not found', async () => {
+      const store = createMockStore([DEFAULT_PARKING_SERVICE]);
+      const service = ServiceRegistryService({ keyValueStore: store });
+
+      const result = await service.getById('nonexistent');
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('add', () => {
+    it('adds a valid service type to the registry', async () => {
+      const store = createMockStore([DEFAULT_PARKING_SERVICE]);
+      const service = ServiceRegistryService({ keyValueStore: store });
+
+      await service.add(BIKE_RENTAL);
+
+      expect(store.set).toHaveBeenCalledWith(
+        STORE_NAME,
+        REGISTRY_KEY,
+        expect.arrayContaining([
+          expect.objectContaining({ id: 'parking' }),
+          expect.objectContaining({ id: 'bike-rental' }),
+        ]),
+      );
+    });
+
+    it('throws on duplicate ID', async () => {
+      const store = createMockStore([DEFAULT_PARKING_SERVICE]);
+      const service = ServiceRegistryService({ keyValueStore: store });
+
+      await expect(service.add(DEFAULT_PARKING_SERVICE)).rejects.toThrow(
+        'already exists',
+      );
+    });
+
+    it('throws on invalid service type data', async () => {
+      const store = createMockStore([]);
+      const service = ServiceRegistryService({ keyValueStore: store });
+
+      const invalid = {
+        id: '',
+        displayName: '',
+        activityType: '',
+        pricing: { ratePerUnit: -1, unitType: 'invalid', roundingStrategy: 'ceiling' },
+      } as unknown as ServiceType;
+
+      await expect(service.add(invalid)).rejects.toThrow('Invalid service type');
+    });
+  });
+
+  describe('update', () => {
+    it('updates an existing service type', async () => {
+      const store = createMockStore([DEFAULT_PARKING_SERVICE]);
+      const service = ServiceRegistryService({ keyValueStore: store });
+
+      await service.update('parking', { displayName: 'Parkir Mobil' });
+
+      expect(store.set).toHaveBeenCalledWith(
+        STORE_NAME,
+        REGISTRY_KEY,
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: 'parking',
+            displayName: 'Parkir Mobil',
+          }),
+        ]),
+      );
+    });
+
+    it('throws when service type not found', async () => {
+      const store = createMockStore([DEFAULT_PARKING_SERVICE]);
+      const service = ServiceRegistryService({ keyValueStore: store });
+
+      await expect(
+        service.update('nonexistent', { displayName: 'Test' }),
+      ).rejects.toThrow('not found');
+    });
+
+    it('preserves the original ID even if updates try to change it', async () => {
+      const store = createMockStore([DEFAULT_PARKING_SERVICE]);
+      const service = ServiceRegistryService({ keyValueStore: store });
+
+      // The update method signature prevents changing ID via Omit<ServiceType, 'id'>
+      await service.update('parking', { displayName: 'Updated Parkir' });
+
+      expect(store.set).toHaveBeenCalledWith(
+        STORE_NAME,
+        REGISTRY_KEY,
+        expect.arrayContaining([
+          expect.objectContaining({ id: 'parking' }),
+        ]),
+      );
+    });
+
+    it('validates the updated entry', async () => {
+      const store = createMockStore([DEFAULT_PARKING_SERVICE]);
+      const service = ServiceRegistryService({ keyValueStore: store });
+
+      await expect(
+        service.update('parking', { displayName: '' }),
+      ).rejects.toThrow('Invalid service type after update');
+    });
+  });
+
+  describe('remove', () => {
+    it('removes an existing service type', async () => {
+      const store = createMockStore([DEFAULT_PARKING_SERVICE, BIKE_RENTAL]);
+      const service = ServiceRegistryService({ keyValueStore: store });
+
+      await service.remove('bike-rental');
+
+      expect(store.set).toHaveBeenCalledWith(
+        STORE_NAME,
+        REGISTRY_KEY,
+        expect.arrayContaining([
+          expect.objectContaining({ id: 'parking' }),
+        ]),
+      );
+      // Verify bike-rental is not in the saved array
+      const savedArg = (store.set as ReturnType<typeof vi.fn>).mock.calls[0][2] as ServiceType[];
+      expect(savedArg.find(s => s.id === 'bike-rental')).toBeUndefined();
+    });
+
+    it('throws when service type not found', async () => {
+      const store = createMockStore([DEFAULT_PARKING_SERVICE]);
+      const service = ServiceRegistryService({ keyValueStore: store });
+
+      await expect(service.remove('nonexistent')).rejects.toThrow('not found');
+    });
+
+    it('can remove the last service type leaving empty registry', async () => {
+      const store = createMockStore([DEFAULT_PARKING_SERVICE]);
+      const service = ServiceRegistryService({ keyValueStore: store });
+
+      await service.remove('parking');
+
+      expect(store.set).toHaveBeenCalledWith(STORE_NAME, REGISTRY_KEY, []);
+    });
+  });
+});

--- a/src/@core/services/__tests__/mbc/storage-health.service.test.ts
+++ b/src/@core/services/__tests__/mbc/storage-health.service.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { KeyValueStoreProtocol } from '@core/protocols/key-value-store';
+
+import { StorageHealthService } from '../../mbc/storage-health.service';
+
+function createMockStore(
+  overrides: Partial<KeyValueStoreProtocol> = {},
+): KeyValueStoreProtocol {
+  return {
+    get: vi.fn().mockResolvedValue(undefined),
+    set: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
+    getAll: vi.fn().mockResolvedValue([]),
+    isAvailable: vi.fn().mockResolvedValue(true),
+    ...overrides,
+  };
+}
+
+describe('StorageHealthService', () => {
+  describe('isAvailable', () => {
+    it('returns true when storage is available', async () => {
+      const store = createMockStore({ isAvailable: vi.fn().mockResolvedValue(true) });
+      const service = StorageHealthService({ keyValueStore: store });
+
+      const result = await service.isAvailable();
+
+      expect(result).toBe(true);
+      expect(store.isAvailable).toHaveBeenCalledOnce();
+    });
+
+    it('returns false when storage is unavailable', async () => {
+      const store = createMockStore({ isAvailable: vi.fn().mockResolvedValue(false) });
+      const service = StorageHealthService({ keyValueStore: store });
+
+      const result = await service.isAvailable();
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('checkWriteCapacity', () => {
+    it('returns canWrite: true when storage is healthy', async () => {
+      const store = createMockStore({
+        isAvailable: vi.fn().mockResolvedValue(true),
+        get: vi.fn().mockResolvedValue('health-check'),
+        set: vi.fn().mockResolvedValue(undefined),
+        delete: vi.fn().mockResolvedValue(undefined),
+      });
+      const service = StorageHealthService({ keyValueStore: store });
+
+      const result = await service.checkWriteCapacity();
+
+      expect(result.canWrite).toBe(true);
+      expect(result.error).toBeUndefined();
+    });
+
+    it('returns unavailable error when storage is not available', async () => {
+      const store = createMockStore({
+        isAvailable: vi.fn().mockResolvedValue(false),
+      });
+      const service = StorageHealthService({ keyValueStore: store });
+
+      const result = await service.checkWriteCapacity();
+
+      expect(result.canWrite).toBe(false);
+      expect(result.error?.type).toBe('unavailable');
+    });
+
+    it('returns write_failed when read-back does not match', async () => {
+      const store = createMockStore({
+        isAvailable: vi.fn().mockResolvedValue(true),
+        get: vi.fn().mockResolvedValue('wrong-value'),
+        set: vi.fn().mockResolvedValue(undefined),
+        delete: vi.fn().mockResolvedValue(undefined),
+      });
+      const service = StorageHealthService({ keyValueStore: store });
+
+      const result = await service.checkWriteCapacity();
+
+      expect(result.canWrite).toBe(false);
+      expect(result.error?.type).toBe('write_failed');
+    });
+
+    it('returns quota_exceeded when set throws QuotaExceededError', async () => {
+      const quotaError = new DOMException('Quota exceeded', 'QuotaExceededError');
+      const store = createMockStore({
+        isAvailable: vi.fn().mockResolvedValue(true),
+        set: vi.fn().mockRejectedValue(quotaError),
+      });
+      const service = StorageHealthService({ keyValueStore: store });
+
+      const result = await service.checkWriteCapacity();
+
+      expect(result.canWrite).toBe(false);
+      expect(result.error?.type).toBe('quota_exceeded');
+    });
+
+    it('returns write_failed for generic errors', async () => {
+      const store = createMockStore({
+        isAvailable: vi.fn().mockResolvedValue(true),
+        set: vi.fn().mockRejectedValue(new Error('Disk I/O error')),
+      });
+      const service = StorageHealthService({ keyValueStore: store });
+
+      const result = await service.checkWriteCapacity();
+
+      expect(result.canWrite).toBe(false);
+      expect(result.error?.type).toBe('write_failed');
+      expect(result.error?.message).toContain('Disk I/O error');
+    });
+
+    it('cleans up test key after successful check', async () => {
+      const deleteFn = vi.fn().mockResolvedValue(undefined);
+      const store = createMockStore({
+        isAvailable: vi.fn().mockResolvedValue(true),
+        get: vi.fn().mockResolvedValue('health-check'),
+        set: vi.fn().mockResolvedValue(undefined),
+        delete: deleteFn,
+      });
+      const service = StorageHealthService({ keyValueStore: store });
+
+      await service.checkWriteCapacity();
+
+      expect(deleteFn).toHaveBeenCalledWith('__test__', '__storage_health_check__');
+    });
+  });
+});

--- a/src/@core/services/mbc/device.service.ts
+++ b/src/@core/services/mbc/device.service.ts
@@ -1,0 +1,47 @@
+import type { AwilixRegistry } from '@di/container';
+
+import { MBC_KEYS } from '@utils/constants/mbc-keys';
+
+export interface DeviceIdResult {
+  deviceId: string;
+  wasRegenerated: boolean;
+}
+
+export interface DeviceServiceInterface {
+  /** Get the current Device_ID from storage. Returns undefined if not found. */
+  getDeviceId(): Promise<string | undefined>;
+  /**
+   * Ensure a Device_ID exists. If missing, generate a new one and persist it.
+   * Returns the deviceId and whether it was newly generated (wasRegenerated).
+   */
+  ensureDeviceId(): Promise<DeviceIdResult>;
+}
+
+export const DeviceService = (
+  deps: Pick<AwilixRegistry, 'keyValueStore'>,
+): DeviceServiceInterface => {
+  const { keyValueStore } = deps;
+
+  const storeName = MBC_KEYS.MBC_STORE_NAME;
+  const key = MBC_KEYS.MBC_DEVICE_ID;
+
+  const getDeviceId = async (): Promise<string | undefined> => {
+    return keyValueStore.get<string>(storeName, key);
+  };
+
+  const ensureDeviceId = async (): Promise<DeviceIdResult> => {
+    const existing = await getDeviceId();
+
+    if (existing) {
+      return { deviceId: existing, wasRegenerated: false };
+    }
+
+    // Generate a new UUID using the Web Crypto API
+    const newId = crypto.randomUUID();
+    await keyValueStore.set(storeName, key, newId);
+
+    return { deviceId: newId, wasRegenerated: true };
+  };
+
+  return { getDeviceId, ensureDeviceId };
+};

--- a/src/@core/services/mbc/models/index.ts
+++ b/src/@core/services/mbc/models/index.ts
@@ -24,7 +24,7 @@ export type {
   AtomicWriteResult,
   AtomicWriteError,
   WriteVerifyResult,
-  StorageQuotaInfo,
+  StorageError,
   NfcCapabilityStatus,
 } from './common.model.ts';
 

--- a/src/@core/services/mbc/nfc.service.ts
+++ b/src/@core/services/mbc/nfc.service.ts
@@ -1,0 +1,99 @@
+import type { AwilixRegistry } from '@di/container';
+import type { NfcProtocol } from '@core/protocols/nfc';
+import type {
+  NfcError,
+  NfcPermissionResult,
+  NfcScanSession,
+  WriteVerifyResult,
+} from '@core/services/mbc/models';
+
+export interface NfcServiceInterface {
+  /** Check if NFC hardware is available */
+  isAvailable(): boolean;
+  /** Request NFC permission from the user */
+  requestPermission(): Promise<NfcPermissionResult>;
+  /** Read raw bytes from an NFC card (one-shot: resolves on first read) */
+  readCard(): Promise<Uint8Array>;
+  /** Write raw bytes to an NFC card */
+  writeCard(data: Uint8Array): Promise<void>;
+  /** Write data and verify by reading back */
+  writeAndVerify(data: Uint8Array): Promise<WriteVerifyResult>;
+}
+
+export const NfcService = (
+  deps: Pick<AwilixRegistry, 'nfcProtocol'>,
+): NfcServiceInterface => {
+  const { nfcProtocol }: { nfcProtocol: NfcProtocol } = deps;
+
+  const isAvailable = (): boolean => {
+    return nfcProtocol.isSupported();
+  };
+
+  const requestPermission = async (): Promise<NfcPermissionResult> => {
+    return nfcProtocol.requestPermission();
+  };
+
+  const readCard = (): Promise<Uint8Array> => {
+    return new Promise<Uint8Array>((resolve, reject) => {
+      let session: NfcScanSession | null = null;
+
+      const onRead = (data: Uint8Array): void => {
+        session?.abort();
+        resolve(data);
+      };
+
+      const onError = (err: NfcError): void => {
+        session?.abort();
+        reject(new Error(`NFC read failed [${err.type}]: ${err.message}`));
+      };
+
+      session = nfcProtocol.startScan(onRead, onError);
+    });
+  };
+
+  const writeCard = async (data: Uint8Array): Promise<void> => {
+    await nfcProtocol.write(data);
+  };
+
+  const writeAndVerify = async (
+    data: Uint8Array,
+  ): Promise<WriteVerifyResult> => {
+    try {
+      // Step 1: Write data to card
+      await nfcProtocol.write(data);
+
+      // Step 2: Read back for verification
+      const readBack = await readCard();
+
+      // Step 3: Compare written vs read
+      if (!arraysEqual(data, readBack)) {
+        return {
+          success: false,
+          error:
+            'Verification failed: data read back from card does not match written data',
+        };
+      }
+
+      return { success: true };
+    } catch (error: unknown) {
+      return {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Write and verify failed due to an unknown error',
+      };
+    }
+  };
+
+  return { isAvailable, requestPermission, readCard, writeCard, writeAndVerify };
+};
+
+/** Compare two Uint8Arrays for byte-level equality */
+function arraysEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}

--- a/src/@core/services/mbc/service-registry.service.ts
+++ b/src/@core/services/mbc/service-registry.service.ts
@@ -1,0 +1,130 @@
+import type { AwilixRegistry } from '@di/container';
+import type { ServiceType } from '@core/services/mbc/models';
+
+import {
+  DEFAULT_PARKING_SERVICE,
+  ServiceTypeFormSchema,
+} from '@core/services/mbc/models';
+import { MBC_KEYS } from '@utils/constants/mbc-keys';
+
+export interface ServiceRegistryServiceInterface {
+  /** Get all registered service types */
+  getAll(): Promise<ServiceType[]>;
+  /** Get a service type by its unique identifier */
+  getById(id: string): Promise<ServiceType | undefined>;
+  /** Add a new service type to the registry */
+  add(serviceType: ServiceType): Promise<void>;
+  /** Update an existing service type's fields */
+  update(id: string, updates: Partial<Omit<ServiceType, 'id'>>): Promise<void>;
+  /** Remove a service type from the registry */
+  remove(id: string): Promise<void>;
+  /** Initialize the registry with defaults if it doesn't exist */
+  initializeDefaults(): Promise<void>;
+}
+
+export const ServiceRegistryService = (
+  deps: Pick<AwilixRegistry, 'keyValueStore'>,
+): ServiceRegistryServiceInterface => {
+  const { keyValueStore } = deps;
+
+  const storeName = MBC_KEYS.MBC_STORE_NAME;
+  const registryKey = MBC_KEYS.MBC_SERVICE_REGISTRY;
+
+  const readRegistry = async (): Promise<ServiceType[]> => {
+    const raw = await keyValueStore.get<ServiceType[]>(storeName, registryKey);
+
+    if (!raw || !Array.isArray(raw)) {
+      return [];
+    }
+
+    // Validate each entry, filter out corrupted ones
+    return raw.filter((entry) => {
+      const result = ServiceTypeFormSchema.safeParse(entry);
+      return result.success;
+    });
+  };
+
+  const writeRegistry = async (registry: ServiceType[]): Promise<void> => {
+    await keyValueStore.set(storeName, registryKey, registry);
+  };
+
+  const getAll = async (): Promise<ServiceType[]> => {
+    return readRegistry();
+  };
+
+  const getById = async (id: string): Promise<ServiceType | undefined> => {
+    const registry = await readRegistry();
+    return registry.find((st) => st.id === id);
+  };
+
+  const add = async (serviceType: ServiceType): Promise<void> => {
+    // Validate the new service type
+    const validation = ServiceTypeFormSchema.safeParse(serviceType);
+    if (!validation.success) {
+      const messages = validation.error.issues
+        .map((i) => `${i.path.join('.')}: ${i.message}`)
+        .join('; ');
+      throw new Error(`Invalid service type: ${messages}`);
+    }
+
+    const registry = await readRegistry();
+
+    // Check for duplicate ID
+    if (registry.some((st) => st.id === serviceType.id)) {
+      throw new Error(
+        `Service type with id "${serviceType.id}" already exists`,
+      );
+    }
+
+    registry.push(serviceType);
+    await writeRegistry(registry);
+  };
+
+  const update = async (
+    id: string,
+    updates: Partial<Omit<ServiceType, 'id'>>,
+  ): Promise<void> => {
+    const registry = await readRegistry();
+    const index = registry.findIndex((st) => st.id === id);
+
+    if (index === -1) {
+      throw new Error(`Service type with id "${id}" not found`);
+    }
+
+    const updated: ServiceType = { ...registry[index], ...updates, id };
+
+    // Validate the updated entry
+    const validation = ServiceTypeFormSchema.safeParse(updated);
+    if (!validation.success) {
+      const messages = validation.error.issues
+        .map((i) => `${i.path.join('.')}: ${i.message}`)
+        .join('; ');
+      throw new Error(`Invalid service type after update: ${messages}`);
+    }
+
+    registry[index] = updated;
+    await writeRegistry(registry);
+  };
+
+  const remove = async (id: string): Promise<void> => {
+    const registry = await readRegistry();
+    const index = registry.findIndex((st) => st.id === id);
+
+    if (index === -1) {
+      throw new Error(`Service type with id "${id}" not found`);
+    }
+
+    registry.splice(index, 1);
+    await writeRegistry(registry);
+  };
+
+  const initializeDefaults = async (): Promise<void> => {
+    const registry = await readRegistry();
+
+    if (registry.length === 0) {
+      await writeRegistry([DEFAULT_PARKING_SERVICE]);
+    }
+  };
+
+  return { getAll, getById, add, update, remove, initializeDefaults };
+};

--- a/src/@core/services/mbc/storage-health.service.ts
+++ b/src/@core/services/mbc/storage-health.service.ts
@@ -1,0 +1,95 @@
+import type { AwilixRegistry } from '@di/container';
+import type { StorageError } from '@core/services/mbc/models';
+
+export interface StorageHealthResult {
+  canWrite: boolean;
+  error?: StorageError;
+}
+
+export interface StorageHealthServiceInterface {
+  /** Check if the underlying storage is accessible and writable */
+  isAvailable(): Promise<boolean>;
+  /** Attempt a test write to detect quota exceeded or other write failures */
+  checkWriteCapacity(): Promise<StorageHealthResult>;
+}
+
+export const StorageHealthService = (
+  deps: Pick<AwilixRegistry, 'keyValueStore'>,
+): StorageHealthServiceInterface => {
+  const { keyValueStore } = deps;
+
+  const isAvailable = async (): Promise<boolean> => {
+    return keyValueStore.isAvailable();
+  };
+
+  const checkWriteCapacity = async (): Promise<StorageHealthResult> => {
+    try {
+      const available = await keyValueStore.isAvailable();
+      if (!available) {
+        return {
+          canWrite: false,
+          error: {
+            type: 'unavailable',
+            message:
+              'localStorage is not available. The browser may be in private mode or storage is restricted.',
+          },
+        };
+      }
+
+      // Attempt a test write/read/delete cycle
+      const testKey = '__storage_health_check__';
+      const testValue = 'health-check';
+      await keyValueStore.set('__test__', testKey, testValue);
+      const readBack = await keyValueStore.get<string>('__test__', testKey);
+      await keyValueStore.delete('__test__', testKey);
+
+      if (readBack !== testValue) {
+        return {
+          canWrite: false,
+          error: {
+            type: 'write_failed',
+            message:
+              'Storage write verification failed — written data does not match read data.',
+          },
+        };
+      }
+
+      return { canWrite: true };
+    } catch (error: unknown) {
+      if (isQuotaExceededError(error)) {
+        return {
+          canWrite: false,
+          error: {
+            type: 'quota_exceeded',
+            message:
+              'Storage quota exceeded. Please clear browser data to free up space.',
+          },
+        };
+      }
+
+      return {
+        canWrite: false,
+        error: {
+          type: 'write_failed',
+          message:
+            error instanceof Error
+              ? `Storage write failed: ${error.message}`
+              : 'Storage write failed due to an unknown error.',
+        },
+      };
+    }
+  };
+
+  return { isAvailable, checkWriteCapacity };
+};
+
+/** Detect QuotaExceededError across browsers */
+function isQuotaExceededError(error: unknown): boolean {
+  if (error instanceof DOMException) {
+    // Chrome, Firefox, Edge
+    if (error.name === 'QuotaExceededError') return true;
+    // Safari (older versions)
+    if (error.code === 22) return true;
+  }
+  return false;
+}

--- a/src/infrastructure/di/container.ts
+++ b/src/infrastructure/di/container.ts
@@ -31,11 +31,21 @@ import {
   UseCaseContainerInterface,
   registerUseCaseModules,
 } from '@di/registry/useCaseContainer';
+import {
+  MbcProtocolContainerInterface,
+  registerMbcProtocolModules,
+} from '@di/registry/mbcProtocolContainer';
+import {
+  MbcServiceContainerInterface,
+  registerMbcServiceModules,
+} from '@di/registry/mbcServiceContainer';
 
 const container = createContainer<AwilixRegistry>();
 
 registerProtocolModules(container);
+registerMbcProtocolModules(container);
 registerServiceModules(container);
+registerMbcServiceModules(container);
 registerTanstackModule(container);
 registerUseCaseModules(container);
 registerLibraryModule(container);
@@ -48,6 +58,8 @@ export default container;
 export type AwilixRegistry = ControllerContainerInterface &
   HelperContainerInterface &
   LibraryContainerInterface &
+  MbcProtocolContainerInterface &
+  MbcServiceContainerInterface &
   ProtocolContainerInterface &
   ReactContainerInterface &
   ServiceContainerInterface &

--- a/src/infrastructure/di/registry/mbcProtocolContainer.ts
+++ b/src/infrastructure/di/registry/mbcProtocolContainer.ts
@@ -1,0 +1,15 @@
+import type { AwilixContainer } from 'awilix';
+import { asValue } from 'awilix';
+
+import type { NfcProtocol } from '@core/protocols/nfc';
+import { webNfcAdapter } from '@src/infrastructure/nfc/webNfcAdapter';
+
+export function registerMbcProtocolModules(container: AwilixContainer) {
+  container.register({
+    nfcProtocol: asValue(webNfcAdapter),
+  });
+}
+
+export interface MbcProtocolContainerInterface {
+  nfcProtocol: NfcProtocol;
+}

--- a/src/infrastructure/di/registry/mbcServiceContainer.ts
+++ b/src/infrastructure/di/registry/mbcServiceContainer.ts
@@ -1,0 +1,43 @@
+import type { AwilixContainer } from 'awilix';
+import { asFunction } from 'awilix';
+
+import type { PricingServiceInterface } from '@core/services/mbc/pricing.service';
+import type { CardDataServiceInterface } from '@core/services/mbc/card-data.service';
+import type { SilentShieldServiceInterface } from '@core/services/mbc/silent-shield.service';
+import type { NfcServiceInterface } from '@core/services/mbc/nfc.service';
+import type { DeviceServiceInterface } from '@core/services/mbc/device.service';
+import type { StorageHealthServiceInterface } from '@core/services/mbc/storage-health.service';
+import type { ServiceRegistryServiceInterface } from '@core/services/mbc/service-registry.service';
+
+import { PricingService } from '@core/services/mbc/pricing.service';
+import { CardDataService } from '@core/services/mbc/card-data.service';
+import { SilentShieldService } from '@core/services/mbc/silent-shield.service';
+import { NfcService } from '@core/services/mbc/nfc.service';
+import { DeviceService } from '@core/services/mbc/device.service';
+import { StorageHealthService } from '@core/services/mbc/storage-health.service';
+import { ServiceRegistryService } from '@core/services/mbc/service-registry.service';
+
+export function registerMbcServiceModules(container: AwilixContainer) {
+  container.register({
+    // Layer 1 — Pure logic services (stateless)
+    pricingService: asFunction(PricingService),
+    cardDataService: asFunction(CardDataService),
+    silentShieldService: asFunction(SilentShieldService),
+
+    // Layer 3 — Stateful services (singleton for shared state)
+    nfcService: asFunction(NfcService).singleton(),
+    deviceService: asFunction(DeviceService).singleton(),
+    storageHealthService: asFunction(StorageHealthService).singleton(),
+    serviceRegistryService: asFunction(ServiceRegistryService).singleton(),
+  });
+}
+
+export interface MbcServiceContainerInterface {
+  pricingService: PricingServiceInterface;
+  cardDataService: CardDataServiceInterface;
+  silentShieldService: SilentShieldServiceInterface;
+  nfcService: NfcServiceInterface;
+  deviceService: DeviceServiceInterface;
+  storageHealthService: StorageHealthServiceInterface;
+  serviceRegistryService: ServiceRegistryServiceInterface;
+}

--- a/src/infrastructure/nfc/webNfcAdapter.ts
+++ b/src/infrastructure/nfc/webNfcAdapter.ts
@@ -1,0 +1,201 @@
+import type { NfcProtocol } from '@core/protocols/nfc';
+import type {
+  NfcError,
+  NfcPermissionResult,
+  NfcScanSession,
+} from '@core/services/mbc/models';
+
+/**
+ * Web NFC API adapter implementing NfcProtocol.
+ *
+ * Wraps the browser's NDEFReader API behind a clean interface.
+ * Card data is stored as a single NDEF text record containing
+ * the encrypted+serialized payload as a base64 string.
+ *
+ * Browser support: Chrome Android 89+.
+ * Requires HTTPS context and user gesture for first scan.
+ */
+export const webNfcAdapter: NfcProtocol = {
+  isSupported(): boolean {
+    return typeof window !== 'undefined' && 'NDEFReader' in window;
+  },
+
+  async requestPermission(): Promise<NfcPermissionResult> {
+    if (!this.isSupported()) {
+      return 'unsupported';
+    }
+
+    try {
+      // Triggering a scan is the only way to request NFC permission
+      // in the Web NFC API. We start and immediately abort.
+      const ndef = new NDEFReader();
+      const controller = new AbortController();
+      await ndef.scan({ signal: controller.signal });
+      controller.abort();
+      return 'granted';
+    } catch (error: unknown) {
+      if (error instanceof DOMException && error.name === 'NotAllowedError') {
+        return 'denied';
+      }
+      return 'denied';
+    }
+  },
+
+  startScan(
+    onRead: (data: Uint8Array) => void,
+    onError: (err: NfcError) => void,
+  ): NfcScanSession {
+    const controller = new AbortController();
+
+    if (!this.isSupported()) {
+      onError({
+        type: 'hardware_unavailable',
+        message: 'Web NFC is not supported on this device or browser',
+      });
+      return { abort: () => controller.abort() };
+    }
+
+    const ndef = new NDEFReader();
+
+    ndef
+      .scan({ signal: controller.signal })
+      .then(() => {
+        ndef.onreading = (event: NDEFReadingEvent) => {
+          try {
+            const data = extractPayload(event.message);
+            onRead(data);
+          } catch {
+            onError({
+              type: 'read_failed',
+              message: 'Failed to extract data from NFC tag',
+            });
+          }
+        };
+
+        ndef.onreadingerror = () => {
+          onError({
+            type: 'read_failed',
+            message: 'Error reading NFC tag — tag may be incompatible',
+          });
+        };
+      })
+      .catch((error: unknown) => {
+        if (error instanceof DOMException) {
+          switch (error.name) {
+            case 'NotAllowedError':
+              onError({
+                type: 'permission_denied',
+                message: 'NFC permission was denied by the user',
+              });
+              break;
+            case 'NotSupportedError':
+              onError({
+                type: 'hardware_unavailable',
+                message: 'NFC hardware is not available on this device',
+              });
+              break;
+            default:
+              onError({
+                type: 'read_failed',
+                message: `NFC scan failed: ${error.message}`,
+              });
+          }
+        } else {
+          onError({
+            type: 'read_failed',
+            message: 'An unexpected error occurred during NFC scan',
+          });
+        }
+      });
+
+    return {
+      abort: () => controller.abort(),
+    };
+  },
+
+  async write(data: Uint8Array): Promise<void> {
+    if (!this.isSupported()) {
+      throw createNfcError(
+        'hardware_unavailable',
+        'Web NFC is not supported on this device or browser',
+      );
+    }
+
+    try {
+      const ndef = new NDEFReader();
+      // Encode as base64 text record to fit within NDEF text record constraints
+      const base64 = uint8ArrayToBase64(data);
+      await ndef.write({
+        records: [{ recordType: 'text', data: base64 }],
+      });
+    } catch (error: unknown) {
+      if (error instanceof DOMException) {
+        switch (error.name) {
+          case 'NotAllowedError':
+            throw createNfcError(
+              'permission_denied',
+              'NFC permission was denied by the user',
+            );
+          case 'NotSupportedError':
+            throw createNfcError(
+              'hardware_unavailable',
+              'NFC hardware is not available on this device',
+            );
+          case 'NetworkError':
+            throw createNfcError(
+              'connection_lost',
+              'NFC connection lost during write — tag may have been removed',
+            );
+          default:
+            throw createNfcError(
+              'write_failed',
+              `NFC write failed: ${error.message}`,
+            );
+        }
+      }
+      throw createNfcError(
+        'write_failed',
+        'An unexpected error occurred during NFC write',
+      );
+    }
+  },
+};
+
+/**
+ * Extract the payload bytes from an NDEF message.
+ * Expects a single text record containing base64-encoded data.
+ */
+function extractPayload(message: NDEFMessage): Uint8Array {
+  for (const record of message.records) {
+    if (record.recordType === 'text' && record.data) {
+      const decoder = new TextDecoder();
+      const base64 = decoder.decode(record.data);
+      return base64ToUint8Array(base64);
+    }
+  }
+  throw new Error('No text record found in NFC tag');
+}
+
+/** Convert Uint8Array to base64 string */
+function uint8ArrayToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+/** Convert base64 string to Uint8Array */
+function base64ToUint8Array(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+/** Helper to create a typed NfcError */
+function createNfcError(type: NfcError['type'], message: string): NfcError {
+  return { type, message };
+}

--- a/types/web-nfc.d.ts
+++ b/types/web-nfc.d.ts
@@ -1,0 +1,59 @@
+/**
+ * Web NFC API type declarations.
+ * @see https://w3c.github.io/web-nfc/
+ *
+ * These types are not included in TypeScript's standard lib
+ * because Web NFC is only supported in Chrome Android 89+.
+ */
+
+interface NDEFMessage {
+  records: ReadonlyArray<NDEFRecord>;
+}
+
+interface NDEFRecord {
+  recordType: string;
+  mediaType?: string;
+  id?: string;
+  data?: DataView;
+  encoding?: string;
+  lang?: string;
+  toRecords?: () => NDEFRecord[];
+}
+
+interface NDEFReadingEvent extends Event {
+  serialNumber: string;
+  message: NDEFMessage;
+}
+
+interface NDEFWriteOptions {
+  overwrite?: boolean;
+  signal?: AbortSignal;
+}
+
+interface NDEFScanOptions {
+  signal?: AbortSignal;
+}
+
+interface NDEFMessageInit {
+  records: NDEFRecordInit[];
+}
+
+interface NDEFRecordInit {
+  recordType: string;
+  mediaType?: string;
+  id?: string;
+  encoding?: string;
+  lang?: string;
+  data?: string | BufferSource | NDEFMessageInit;
+}
+
+declare class NDEFReader {
+  constructor();
+  onreading: ((event: NDEFReadingEvent) => void) | null;
+  onreadingerror: ((event: Event) => void) | null;
+  scan(options?: NDEFScanOptions): Promise<void>;
+  write(
+    message: NDEFMessageInit | string,
+    options?: NDEFWriteOptions,
+  ): Promise<void>;
+}


### PR DESCRIPTION
## Phase 3: Layer 2-3 — I/O Adapters & Stateful Services

### Changes
- **webNfcAdapter** — NDEFReader wrapper with base64 encoding, error mapping
- **nfc.service** — readCard (one-shot), writeCard, writeAndVerify
- **storage-health.service** — isAvailable, checkWriteCapacity (quota detection)
- **device.service** — Device_ID lifecycle (get/ensure/regenerate)
- **service-registry.service** — CRUD + Zod validation + initializeDefaults
- **DI wiring** — mbcProtocolContainer, mbcServiceContainer, root container update
- **Web NFC types** — TypeScript declarations for NDEFReader API
- **@developer agent** — New coding agent with full workspace permissions
- **Wiki Phase Reports** — Detailed reports for Phase 1, 2, 3

### Testing
- 61 tests total (45 new + 16 existing), all passing
- 4 new test files covering positive, negative, and edge cases

Closes #7, closes #8, closes #9, closes #10, closes #11, closes #12, closes #13, closes #14