### PR TITLE
feat(mbc): Phase 4 — Use cases with full test coverage

### DIFF
--- a/.kiro/specs/membership-benefit-card/tasks.md
+++ b/.kiro/specs/membership-benefit-card/tasks.md
@@ -200,22 +200,22 @@ This plan implements the MBC feature following a strict bottom-up build order: d
 - [x] 8. Checkpoint — Verify services and DI wiring
   - Ensure all tests pass, ask the user if questions arise.
 
-- [ ] 9. Layer 4 — Use cases (orchestrate services)
-  - [ ] 9.1 Implement RegisterMember use case
+- [x] 9. Layer 4 — Use cases (orchestrate services)
+  - [x] 9.1 Implement RegisterMember use case
     - Create `src/@core/use_case/mbc/RegisterMember.ts`
     - Orchestrate: read card → decrypt → deserialize → validate blank card → apply registration → serialize → encrypt → atomic write with verify
     - Reject if card already has member data
     - Return `OperationResult` with member details and initial balance 0
     - _Requirements: 4.1, 4.2, 4.3, 4.4, 3.5, 18.1_
 
-  - [ ] 9.2 Implement TopUpBalance use case
+  - [x] 9.2 Implement TopUpBalance use case
     - Create `src/@core/use_case/mbc/TopUpBalance.ts`
     - Orchestrate: read card → decrypt → deserialize → validate registered card → apply top-up → append transaction log → serialize → encrypt → atomic write with verify
     - Reject if card is not registered
     - Return `OperationResult` with previous balance, amount, new balance
     - _Requirements: 5.1, 5.2, 5.3, 5.4, 5.5, 10.1, 3.5, 18.1_
 
-  - [ ] 9.3 Implement CheckIn use case
+  - [x] 9.3 Implement CheckIn use case
     - Create `src/@core/use_case/mbc/CheckIn.ts`
     - Orchestrate: read card → decrypt → deserialize → validate no active check-in → apply check-in (timestamp, serviceTypeId, deviceId) → serialize → encrypt → atomic write with verify
     - Reject if already checked in (double tap-in prevention)
@@ -224,7 +224,7 @@ This plan implements the MBC feature following a strict bottom-up build order: d
     - Return `CheckInResult` with member name, entry time, service type name
     - _Requirements: 6.1, 6.2, 6.3, 6.4, 6.5, 6.7, 6.8, 7.3, 18.1, 18.5_
 
-  - [ ] 9.4 Implement CheckOut use case
+  - [x] 9.4 Implement CheckOut use case
     - Create `src/@core/use_case/mbc/CheckOut.ts`
     - Orchestrate: read card → decrypt → deserialize → validate active check-in → validate device ID match → lookup service type from registry → calculate fee → validate balance sufficient → apply check-out (deduct fee, clear check-in, append transaction log) → serialize → encrypt → atomic write with verify
     - Reject if not checked in (double tap-out prevention)
@@ -243,14 +243,14 @@ This plan implements the MBC feature following a strict bottom-up build order: d
     - Mock NFC and storage services
     - **Validates: Requirements 19.3, 19.4**
 
-  - [ ] 9.6 Implement ReadCard use case
+  - [x] 9.6 Implement ReadCard use case
     - Create `src/@core/use_case/mbc/ReadCard.ts`
     - Orchestrate: read card → decrypt → deserialize → return `CardData`
     - Read-only — no writes
     - Reject if card data is invalid/corrupted
     - _Requirements: 9.1, 9.2, 9.3, 9.4, 2.3_
 
-  - [ ] 9.7 Implement ManualCalculation use case
+  - [x] 9.7 Implement ManualCalculation use case
     - Create `src/@core/use_case/mbc/ManualCalculation.ts`
     - Accept check-in timestamp and service type ID as input
     - Lookup service type from registry → calculate fee using current time as check-out
@@ -258,23 +258,23 @@ This plan implements the MBC feature following a strict bottom-up build order: d
     - Return `FeeResult`
     - _Requirements: 21.2, 21.3, 21.4, 21.5, 21.7_
 
-  - [ ] 9.8 Implement ManageServiceRegistry use case
+  - [x] 9.8 Implement ManageServiceRegistry use case
     - Create `src/@core/use_case/mbc/ManageServiceRegistry.ts`
     - Expose `getAll`, `add`, `update`, `remove` operations delegating to `ServiceRegistryService`
     - Initialize defaults on first access
     - _Requirements: 15.1, 15.2, 15.3, 15.4, 15.5, 15.6, 15.7, 16.1, 16.2, 16.3, 16.5_
 
-  - [ ]* 9.9 Write unit tests for use cases
+  - [x]* 9.9 Write unit tests for use cases
     - Create test files in `src/@core/use_case/__tests__/mbc/` for `RegisterMember`, `TopUpBalance`, `CheckIn`, `ReadCard`, `ManualCalculation`, `ManageServiceRegistry`
     - Mock all service dependencies via partial `AwilixRegistry`
     - Test success paths, rejection conditions, and error handling
     - _Requirements: 4.2, 4.3, 5.2, 5.5, 6.2, 6.3, 8.3, 8.7, 8.8, 8.10, 9.4, 21.5_
 
-- [ ] 10. Checkpoint — Verify use cases
+- [x] 10. Checkpoint — Verify use cases
   - Ensure all tests pass, ask the user if questions arise.
 
-- [ ] 11. Layer 4 — Use case DI registration
-  - [ ] 11.1 Create MBC use case container
+- [x] 11. Layer 4 — Use case DI registration
+  - [x] 11.1 Create MBC use case container
     - Create `src/infrastructure/di/registry/mbcUseCaseContainer.ts`
     - Register all MBC use cases: `registerMemberUseCase`, `topUpBalanceUseCase`, `checkInUseCase`, `checkOutUseCase`, `readCardUseCase`, `manualCalculationUseCase`, `manageServiceRegistryUseCase`
     - Export `MbcUseCaseContainerInterface`

--- a/src/@core/services/__tests__/mbc/nfc.service.test.ts
+++ b/src/@core/services/__tests__/mbc/nfc.service.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import type { NfcProtocol } from '@core/protocols/nfc';
 import type { NfcError, NfcScanSession } from '@core/services/mbc/models';

--- a/src/@core/services/__tests__/mbc/service-registry.service.test.ts
+++ b/src/@core/services/__tests__/mbc/service-registry.service.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import type { KeyValueStoreProtocol } from '@core/protocols/key-value-store';
 import type { ServiceType } from '@core/services/mbc/models';
@@ -17,17 +17,6 @@ const BIKE_RENTAL: ServiceType = {
   pricing: {
     ratePerUnit: 5000,
     unitType: 'per-hour',
-    roundingStrategy: 'ceiling',
-  },
-};
-
-const GYM_SESSION: ServiceType = {
-  id: 'gym-session',
-  displayName: 'Gym Session',
-  activityType: 'gym-session',
-  pricing: {
-    ratePerUnit: 15000,
-    unitType: 'per-visit',
     roundingStrategy: 'ceiling',
   },
 };

--- a/src/@core/services/__tests__/mbc/storage-health.service.test.ts
+++ b/src/@core/services/__tests__/mbc/storage-health.service.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import type { KeyValueStoreProtocol } from '@core/protocols/key-value-store';
 

--- a/src/@core/use_case/__tests__/mbc/CheckIn.test.ts
+++ b/src/@core/use_case/__tests__/mbc/CheckIn.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { CardData } from '@core/services/mbc/models';
+import type { NfcServiceInterface } from '@core/services/mbc/nfc.service';
+import type { CardDataServiceInterface } from '@core/services/mbc/card-data.service';
+import type { SilentShieldServiceInterface } from '@core/services/mbc/silent-shield.service';
+
+import { CheckInUseCase } from '../../mbc/CheckIn';
+
+const REGISTERED_CARD: CardData = {
+  version: 1,
+  member: { name: 'John Doe', memberId: 'M001' },
+  balance: 10000,
+  checkIn: null,
+  transactions: [],
+};
+
+const CHECKED_IN_CARD: CardData = {
+  ...REGISTERED_CARD,
+  checkIn: {
+    timestamp: '2024-01-01T10:00:00.000Z',
+    serviceTypeId: 'parking',
+    deviceId: 'device-123',
+  },
+};
+
+function createMocks(cardData: CardData = REGISTERED_CARD) {
+  const nfcService: NfcServiceInterface = {
+    isAvailable: vi.fn().mockReturnValue(true),
+    requestPermission: vi.fn().mockResolvedValue('granted'),
+    readCard: vi.fn().mockResolvedValue(new Uint8Array([1])),
+    writeCard: vi.fn().mockResolvedValue(undefined),
+    writeAndVerify: vi.fn().mockResolvedValue({ success: true }),
+  };
+
+  const cardDataService: CardDataServiceInterface = {
+    serialize: vi.fn().mockReturnValue(new Uint8Array([10])),
+    deserialize: vi.fn().mockReturnValue(cardData),
+    validate: vi.fn().mockReturnValue({ success: true }),
+    applyRegistration: vi.fn(),
+    applyTopUp: vi.fn(),
+    applyCheckIn: vi.fn().mockImplementation((card, serviceTypeId, deviceId, timestamp) => ({
+      ...card,
+      checkIn: { timestamp, serviceTypeId, deviceId },
+    })),
+    applyCheckOut: vi.fn(),
+    appendTransactionLog: vi.fn(),
+  };
+
+  const silentShieldService: SilentShieldServiceInterface = {
+    encrypt: vi.fn().mockReturnValue(new Uint8Array([99])),
+    decrypt: vi.fn().mockReturnValue(new Uint8Array([1])),
+  };
+
+  return { nfcService, cardDataService, silentShieldService };
+}
+
+describe('CheckInUseCase', () => {
+  it('checks in successfully', async () => {
+    const mocks = createMocks();
+    const useCase = CheckInUseCase(mocks);
+
+    const result = await useCase.execute({
+      serviceTypeId: 'parking',
+      serviceTypeName: 'Parkir',
+      deviceId: 'device-abc',
+    });
+
+    expect(result.memberName).toBe('John Doe');
+    expect(result.serviceTypeName).toBe('Parkir');
+    expect(result.entryTime).toBeDefined();
+    expect(mocks.nfcService.writeAndVerify).toHaveBeenCalledOnce();
+  });
+
+  it('uses simulation timestamp when provided', async () => {
+    const mocks = createMocks();
+    const useCase = CheckInUseCase(mocks);
+    const simTime = '2024-06-15T08:00:00.000Z';
+
+    const result = await useCase.execute({
+      serviceTypeId: 'parking',
+      serviceTypeName: 'Parkir',
+      deviceId: 'device-abc',
+      simulationTimestamp: simTime,
+    });
+
+    expect(result.entryTime).toBe(simTime);
+    expect(mocks.cardDataService.applyCheckIn).toHaveBeenCalledWith(
+      expect.anything(),
+      'parking',
+      'device-abc',
+      simTime,
+    );
+  });
+
+  it('rejects double check-in', async () => {
+    const mocks = createMocks(CHECKED_IN_CARD);
+    const useCase = CheckInUseCase(mocks);
+
+    await expect(
+      useCase.execute({
+        serviceTypeId: 'parking',
+        serviceTypeName: 'Parkir',
+        deviceId: 'device-abc',
+      }),
+    ).rejects.toThrow('already checked in');
+  });
+
+  it('rejects unregistered card', async () => {
+    const unregistered: CardData = {
+      version: 1,
+      member: { name: '', memberId: '' },
+      balance: 0,
+      checkIn: null,
+      transactions: [],
+    };
+    const mocks = createMocks(unregistered);
+    const useCase = CheckInUseCase(mocks);
+
+    await expect(
+      useCase.execute({
+        serviceTypeId: 'parking',
+        serviceTypeName: 'Parkir',
+        deviceId: 'device-abc',
+      }),
+    ).rejects.toThrow('not registered');
+  });
+
+  it('throws when write verification fails', async () => {
+    const mocks = createMocks();
+    (mocks.nfcService.writeAndVerify as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: false,
+      error: 'Tag removed',
+    });
+    const useCase = CheckInUseCase(mocks);
+
+    await expect(
+      useCase.execute({
+        serviceTypeId: 'parking',
+        serviceTypeName: 'Parkir',
+        deviceId: 'device-abc',
+      }),
+    ).rejects.toThrow('Check-in failed');
+  });
+});

--- a/src/@core/use_case/__tests__/mbc/CheckOut.test.ts
+++ b/src/@core/use_case/__tests__/mbc/CheckOut.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { CardData, ServiceType } from '@core/services/mbc/models';
+import type { NfcServiceInterface } from '@core/services/mbc/nfc.service';
+import type { CardDataServiceInterface } from '@core/services/mbc/card-data.service';
+import type { SilentShieldServiceInterface } from '@core/services/mbc/silent-shield.service';
+import type { PricingServiceInterface } from '@core/services/mbc/pricing.service';
+import type { ServiceRegistryServiceInterface } from '@core/services/mbc/service-registry.service';
+
+import { CheckOutUseCase } from '../../mbc/CheckOut';
+
+const PARKING_SERVICE: ServiceType = {
+  id: 'parking',
+  displayName: 'Parkir',
+  activityType: 'parking-fee',
+  pricing: { ratePerUnit: 2000, unitType: 'per-hour', roundingStrategy: 'ceiling' },
+};
+
+const CHECKED_IN_CARD: CardData = {
+  version: 1,
+  member: { name: 'John Doe', memberId: 'M001' },
+  balance: 50000,
+  checkIn: {
+    timestamp: '2024-01-01T10:00:00.000Z',
+    serviceTypeId: 'parking',
+    deviceId: 'device-123',
+  },
+  transactions: [],
+};
+
+function createMocks(cardData: CardData = CHECKED_IN_CARD) {
+  const nfcService: NfcServiceInterface = {
+    isAvailable: vi.fn().mockReturnValue(true),
+    requestPermission: vi.fn().mockResolvedValue('granted'),
+    readCard: vi.fn().mockResolvedValue(new Uint8Array([1])),
+    writeCard: vi.fn().mockResolvedValue(undefined),
+    writeAndVerify: vi.fn().mockResolvedValue({ success: true }),
+  };
+
+  const cardDataService: CardDataServiceInterface = {
+    serialize: vi.fn().mockReturnValue(new Uint8Array([10])),
+    deserialize: vi.fn().mockReturnValue(cardData),
+    validate: vi.fn().mockReturnValue({ success: true }),
+    applyRegistration: vi.fn(),
+    applyTopUp: vi.fn(),
+    applyCheckIn: vi.fn(),
+    applyCheckOut: vi.fn().mockImplementation((card, fee) => ({
+      ...card,
+      balance: card.balance - fee,
+      checkIn: null,
+    })),
+    appendTransactionLog: vi.fn(),
+  };
+
+  const silentShieldService: SilentShieldServiceInterface = {
+    encrypt: vi.fn().mockReturnValue(new Uint8Array([99])),
+    decrypt: vi.fn().mockReturnValue(new Uint8Array([1])),
+  };
+
+  const pricingService: PricingServiceInterface = {
+    calculateFee: vi.fn().mockReturnValue({
+      fee: 6000,
+      usageUnits: 3,
+      unitLabel: 'jam',
+      ratePerUnit: 2000,
+      roundingApplied: 'ceiling',
+    }),
+  };
+
+  const serviceRegistryService: ServiceRegistryServiceInterface = {
+    getAll: vi.fn().mockResolvedValue([PARKING_SERVICE]),
+    getById: vi.fn().mockResolvedValue(PARKING_SERVICE),
+    add: vi.fn().mockResolvedValue(undefined),
+    update: vi.fn().mockResolvedValue(undefined),
+    remove: vi.fn().mockResolvedValue(undefined),
+    initializeDefaults: vi.fn().mockResolvedValue(undefined),
+  };
+
+  return { nfcService, cardDataService, silentShieldService, pricingService, serviceRegistryService };
+}
+
+describe('CheckOutUseCase', () => {
+  it('processes check-out successfully', async () => {
+    const mocks = createMocks();
+    const useCase = CheckOutUseCase(mocks);
+
+    const result = await useCase.execute({ currentDeviceId: 'device-123' });
+
+    expect(result.serviceTypeName).toBe('Parkir');
+    expect(result.fee).toBe(6000);
+    expect(result.remainingBalance).toBe(44000);
+    expect(result.feeBreakdown.usageUnits).toBe(3);
+    expect(mocks.nfcService.writeAndVerify).toHaveBeenCalledOnce();
+  });
+
+  it('rejects when not checked in', async () => {
+    const notCheckedIn: CardData = { ...CHECKED_IN_CARD, checkIn: null };
+    const mocks = createMocks(notCheckedIn);
+    const useCase = CheckOutUseCase(mocks);
+
+    await expect(
+      useCase.execute({ currentDeviceId: 'device-123' }),
+    ).rejects.toThrow('has not checked in');
+  });
+
+  it('rejects on device ID mismatch', async () => {
+    const mocks = createMocks();
+    const useCase = CheckOutUseCase(mocks);
+
+    await expect(
+      useCase.execute({ currentDeviceId: 'wrong-device' }),
+    ).rejects.toThrow('Device mismatch');
+  });
+
+  it('rejects when service type not found', async () => {
+    const mocks = createMocks();
+    (mocks.serviceRegistryService.getById as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+    const useCase = CheckOutUseCase(mocks);
+
+    await expect(
+      useCase.execute({ currentDeviceId: 'device-123' }),
+    ).rejects.toThrow('not found in registry');
+  });
+
+  it('rejects when balance is insufficient', async () => {
+    const lowBalance: CardData = { ...CHECKED_IN_CARD, balance: 1000 };
+    const mocks = createMocks(lowBalance);
+    const useCase = CheckOutUseCase(mocks);
+
+    await expect(
+      useCase.execute({ currentDeviceId: 'device-123' }),
+    ).rejects.toThrow('Insufficient balance');
+  });
+
+  it('attempts rollback when write verification fails', async () => {
+    const mocks = createMocks();
+    (mocks.nfcService.writeAndVerify as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: false,
+      error: 'Tag removed',
+    });
+    const useCase = CheckOutUseCase(mocks);
+
+    await expect(
+      useCase.execute({ currentDeviceId: 'device-123' }),
+    ).rejects.toThrow('rolled back');
+    // Verify rollback was attempted
+    expect(mocks.nfcService.writeCard).toHaveBeenCalledOnce();
+  });
+
+  it('reports critical error when rollback also fails', async () => {
+    const mocks = createMocks();
+    (mocks.nfcService.writeAndVerify as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: false,
+      error: 'Tag removed',
+    });
+    (mocks.nfcService.writeCard as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('Rollback write failed'),
+    );
+    const useCase = CheckOutUseCase(mocks);
+
+    await expect(
+      useCase.execute({ currentDeviceId: 'device-123' }),
+    ).rejects.toThrow('CRITICAL');
+  });
+});

--- a/src/@core/use_case/__tests__/mbc/ManageServiceRegistry.test.ts
+++ b/src/@core/use_case/__tests__/mbc/ManageServiceRegistry.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ServiceType } from '@core/services/mbc/models';
+import type { ServiceRegistryServiceInterface } from '@core/services/mbc/service-registry.service';
+
+import { DEFAULT_PARKING_SERVICE } from '@core/services/mbc/models';
+import { ManageServiceRegistryUseCase } from '../../mbc/ManageServiceRegistry';
+
+const BIKE_RENTAL: ServiceType = {
+  id: 'bike-rental',
+  displayName: 'Sewa Sepeda',
+  activityType: 'bike-rental',
+  pricing: { ratePerUnit: 5000, unitType: 'per-hour', roundingStrategy: 'ceiling' },
+};
+
+function createMocks() {
+  const serviceRegistryService: ServiceRegistryServiceInterface = {
+    getAll: vi.fn().mockResolvedValue([DEFAULT_PARKING_SERVICE]),
+    getById: vi.fn().mockResolvedValue(DEFAULT_PARKING_SERVICE),
+    add: vi.fn().mockResolvedValue(undefined),
+    update: vi.fn().mockResolvedValue(undefined),
+    remove: vi.fn().mockResolvedValue(undefined),
+    initializeDefaults: vi.fn().mockResolvedValue(undefined),
+  };
+
+  return { serviceRegistryService };
+}
+
+describe('ManageServiceRegistryUseCase', () => {
+  it('initializes defaults on first getAll call', async () => {
+    const mocks = createMocks();
+    const useCase = ManageServiceRegistryUseCase(mocks);
+
+    await useCase.getAll();
+
+    expect(mocks.serviceRegistryService.initializeDefaults).toHaveBeenCalledOnce();
+    expect(mocks.serviceRegistryService.getAll).toHaveBeenCalledOnce();
+  });
+
+  it('does not re-initialize on subsequent calls', async () => {
+    const mocks = createMocks();
+    const useCase = ManageServiceRegistryUseCase(mocks);
+
+    await useCase.getAll();
+    await useCase.getAll();
+
+    // initializeDefaults should only be called once
+    expect(mocks.serviceRegistryService.initializeDefaults).toHaveBeenCalledOnce();
+    expect(mocks.serviceRegistryService.getAll).toHaveBeenCalledTimes(2);
+  });
+
+  it('delegates add to service', async () => {
+    const mocks = createMocks();
+    const useCase = ManageServiceRegistryUseCase(mocks);
+
+    await useCase.add(BIKE_RENTAL);
+
+    expect(mocks.serviceRegistryService.add).toHaveBeenCalledWith(BIKE_RENTAL);
+  });
+
+  it('delegates update to service', async () => {
+    const mocks = createMocks();
+    const useCase = ManageServiceRegistryUseCase(mocks);
+
+    await useCase.update('parking', { displayName: 'Parkir Mobil' });
+
+    expect(mocks.serviceRegistryService.update).toHaveBeenCalledWith(
+      'parking',
+      { displayName: 'Parkir Mobil' },
+    );
+  });
+
+  it('delegates remove to service', async () => {
+    const mocks = createMocks();
+    const useCase = ManageServiceRegistryUseCase(mocks);
+
+    await useCase.remove('parking');
+
+    expect(mocks.serviceRegistryService.remove).toHaveBeenCalledWith('parking');
+  });
+
+  it('explicit initializeDefaults sets initialized flag', async () => {
+    const mocks = createMocks();
+    const useCase = ManageServiceRegistryUseCase(mocks);
+
+    await useCase.initializeDefaults();
+    await useCase.getAll();
+
+    // initializeDefaults called once explicitly, not again on getAll
+    expect(mocks.serviceRegistryService.initializeDefaults).toHaveBeenCalledOnce();
+  });
+});

--- a/src/@core/use_case/__tests__/mbc/ManualCalculation.test.ts
+++ b/src/@core/use_case/__tests__/mbc/ManualCalculation.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ServiceType } from '@core/services/mbc/models';
+import type { PricingServiceInterface } from '@core/services/mbc/pricing.service';
+import type { ServiceRegistryServiceInterface } from '@core/services/mbc/service-registry.service';
+
+import { ManualCalculationUseCase } from '../../mbc/ManualCalculation';
+
+const PARKING_SERVICE: ServiceType = {
+  id: 'parking',
+  displayName: 'Parkir',
+  activityType: 'parking-fee',
+  pricing: { ratePerUnit: 2000, unitType: 'per-hour', roundingStrategy: 'ceiling' },
+};
+
+function createMocks() {
+  const pricingService: PricingServiceInterface = {
+    calculateFee: vi.fn().mockReturnValue({
+      fee: 4000,
+      usageUnits: 2,
+      unitLabel: 'jam',
+      ratePerUnit: 2000,
+      roundingApplied: 'ceiling',
+    }),
+  };
+
+  const serviceRegistryService: ServiceRegistryServiceInterface = {
+    getAll: vi.fn().mockResolvedValue([PARKING_SERVICE]),
+    getById: vi.fn().mockResolvedValue(PARKING_SERVICE),
+    add: vi.fn().mockResolvedValue(undefined),
+    update: vi.fn().mockResolvedValue(undefined),
+    remove: vi.fn().mockResolvedValue(undefined),
+    initializeDefaults: vi.fn().mockResolvedValue(undefined),
+  };
+
+  return { pricingService, serviceRegistryService };
+}
+
+describe('ManualCalculationUseCase', () => {
+  it('calculates fee successfully', async () => {
+    const mocks = createMocks();
+    const useCase = ManualCalculationUseCase(mocks);
+
+    const result = await useCase.execute({
+      checkInTimestamp: '2024-01-01T10:00:00.000Z',
+      serviceTypeId: 'parking',
+    });
+
+    expect(result.fee).toBe(4000);
+    expect(result.usageUnits).toBe(2);
+    expect(result.ratePerUnit).toBe(2000);
+    expect(mocks.pricingService.calculateFee).toHaveBeenCalledOnce();
+  });
+
+  it('rejects when service type not found', async () => {
+    const mocks = createMocks();
+    (mocks.serviceRegistryService.getById as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+    const useCase = ManualCalculationUseCase(mocks);
+
+    await expect(
+      useCase.execute({
+        checkInTimestamp: '2024-01-01T10:00:00.000Z',
+        serviceTypeId: 'nonexistent',
+      }),
+    ).rejects.toThrow('not found in registry');
+  });
+
+  it('rejects invalid timestamp format', async () => {
+    const mocks = createMocks();
+    const useCase = ManualCalculationUseCase(mocks);
+
+    await expect(
+      useCase.execute({
+        checkInTimestamp: 'not-a-date',
+        serviceTypeId: 'parking',
+      }),
+    ).rejects.toThrow('Invalid check-in timestamp');
+  });
+
+  it('does not perform any NFC operations', async () => {
+    const mocks = createMocks();
+    const useCase = ManualCalculationUseCase(mocks);
+
+    await useCase.execute({
+      checkInTimestamp: '2024-01-01T10:00:00.000Z',
+      serviceTypeId: 'parking',
+    });
+
+    // ManualCalculation should never touch NFC
+    expect(mocks.pricingService.calculateFee).toHaveBeenCalledOnce();
+  });
+});

--- a/src/@core/use_case/__tests__/mbc/ReadCard.test.ts
+++ b/src/@core/use_case/__tests__/mbc/ReadCard.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { CardData } from '@core/services/mbc/models';
+import type { NfcServiceInterface } from '@core/services/mbc/nfc.service';
+import type { CardDataServiceInterface } from '@core/services/mbc/card-data.service';
+import type { SilentShieldServiceInterface } from '@core/services/mbc/silent-shield.service';
+
+import { ReadCardUseCase } from '../../mbc/ReadCard';
+
+const REGISTERED_CARD: CardData = {
+  version: 1,
+  member: { name: 'John Doe', memberId: 'M001' },
+  balance: 25000,
+  checkIn: null,
+  transactions: [
+    { amount: 50000, timestamp: '2024-01-01T09:00:00.000Z', activityType: 'top-up', serviceTypeId: 'top-up' },
+    { amount: -6000, timestamp: '2024-01-01T13:00:00.000Z', activityType: 'parking-fee', serviceTypeId: 'parking' },
+  ],
+};
+
+function createMocks(cardData: CardData = REGISTERED_CARD) {
+  const nfcService: NfcServiceInterface = {
+    isAvailable: vi.fn().mockReturnValue(true),
+    requestPermission: vi.fn().mockResolvedValue('granted'),
+    readCard: vi.fn().mockResolvedValue(new Uint8Array([1])),
+    writeCard: vi.fn().mockResolvedValue(undefined),
+    writeAndVerify: vi.fn().mockResolvedValue({ success: true }),
+  };
+
+  const cardDataService: CardDataServiceInterface = {
+    serialize: vi.fn().mockReturnValue(new Uint8Array([10])),
+    deserialize: vi.fn().mockReturnValue(cardData),
+    validate: vi.fn().mockReturnValue({ success: true }),
+    applyRegistration: vi.fn(),
+    applyTopUp: vi.fn(),
+    applyCheckIn: vi.fn(),
+    applyCheckOut: vi.fn(),
+    appendTransactionLog: vi.fn(),
+  };
+
+  const silentShieldService: SilentShieldServiceInterface = {
+    encrypt: vi.fn().mockReturnValue(new Uint8Array([99])),
+    decrypt: vi.fn().mockReturnValue(new Uint8Array([1])),
+  };
+
+  return { nfcService, cardDataService, silentShieldService };
+}
+
+describe('ReadCardUseCase', () => {
+  it('reads card data successfully', async () => {
+    const mocks = createMocks();
+    const useCase = ReadCardUseCase(mocks);
+
+    const result = await useCase.execute();
+
+    expect(result.member.name).toBe('John Doe');
+    expect(result.balance).toBe(25000);
+    expect(result.transactions).toHaveLength(2);
+    // Verify no writes occurred
+    expect(mocks.nfcService.writeCard).not.toHaveBeenCalled();
+    expect(mocks.nfcService.writeAndVerify).not.toHaveBeenCalled();
+  });
+
+  it('rejects unregistered card', async () => {
+    const unregistered: CardData = {
+      version: 1,
+      member: { name: '', memberId: '' },
+      balance: 0,
+      checkIn: null,
+      transactions: [],
+    };
+    const mocks = createMocks(unregistered);
+    const useCase = ReadCardUseCase(mocks);
+
+    await expect(useCase.execute()).rejects.toThrow('not registered');
+  });
+
+  it('throws when NFC read fails', async () => {
+    const mocks = createMocks();
+    (mocks.nfcService.readCard as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('NFC read failed'),
+    );
+    const useCase = ReadCardUseCase(mocks);
+
+    await expect(useCase.execute()).rejects.toThrow('NFC read failed');
+  });
+
+  it('throws when decryption fails', async () => {
+    const mocks = createMocks();
+    (mocks.silentShieldService.decrypt as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error('Decryption failed: invalid auth tag');
+    });
+    const useCase = ReadCardUseCase(mocks);
+
+    await expect(useCase.execute()).rejects.toThrow('Decryption failed');
+  });
+
+  it('throws when deserialization fails (corrupted data)', async () => {
+    const mocks = createMocks();
+    (mocks.cardDataService.deserialize as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error('Invalid card data: version: Required');
+    });
+    const useCase = ReadCardUseCase(mocks);
+
+    await expect(useCase.execute()).rejects.toThrow('Invalid card data');
+  });
+});

--- a/src/@core/use_case/__tests__/mbc/RegisterMember.test.ts
+++ b/src/@core/use_case/__tests__/mbc/RegisterMember.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { NfcServiceInterface } from '@core/services/mbc/nfc.service';
+import type { CardDataServiceInterface } from '@core/services/mbc/card-data.service';
+import type { SilentShieldServiceInterface } from '@core/services/mbc/silent-shield.service';
+
+import { RegisterMemberUseCase } from '../../mbc/RegisterMember';
+
+function createMocks() {
+  const nfcService: NfcServiceInterface = {
+    isAvailable: vi.fn().mockReturnValue(true),
+    requestPermission: vi.fn().mockResolvedValue('granted'),
+    readCard: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
+    writeCard: vi.fn().mockResolvedValue(undefined),
+    writeAndVerify: vi.fn().mockResolvedValue({ success: true }),
+  };
+
+  const cardDataService: CardDataServiceInterface = {
+    serialize: vi.fn().mockReturnValue(new Uint8Array([10, 20])),
+    deserialize: vi.fn(),
+    validate: vi.fn().mockReturnValue({ success: true }),
+    applyRegistration: vi.fn().mockImplementation((card, member) => ({
+      ...card,
+      version: 1,
+      member,
+      balance: 0,
+      checkIn: null,
+      transactions: [],
+    })),
+    applyTopUp: vi.fn(),
+    applyCheckIn: vi.fn(),
+    applyCheckOut: vi.fn(),
+    appendTransactionLog: vi.fn(),
+  };
+
+  const silentShieldService: SilentShieldServiceInterface = {
+    encrypt: vi.fn().mockReturnValue(new Uint8Array([99])),
+    decrypt: vi.fn(),
+  };
+
+  return { nfcService, cardDataService, silentShieldService };
+}
+
+describe('RegisterMemberUseCase', () => {
+  it('registers a blank card successfully', async () => {
+    const mocks = createMocks();
+    // Simulate blank card: decrypt throws (no valid data)
+    (mocks.silentShieldService.decrypt as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error('Decryption failed');
+    });
+
+    const useCase = RegisterMemberUseCase(mocks);
+    const result = await useCase.execute({
+      member: { name: 'John Doe', memberId: 'M001' },
+    });
+
+    expect(result.type).toBe('registration');
+    expect(result.memberName).toBe('John Doe');
+    expect(result.newBalance).toBe(0);
+    expect(mocks.nfcService.writeAndVerify).toHaveBeenCalledOnce();
+  });
+
+  it('rejects if card already has member data', async () => {
+    const mocks = createMocks();
+    (mocks.silentShieldService.decrypt as ReturnType<typeof vi.fn>).mockReturnValue(new Uint8Array([1]));
+    (mocks.cardDataService.deserialize as ReturnType<typeof vi.fn>).mockReturnValue({
+      version: 1,
+      member: { name: 'Existing User', memberId: 'M999' },
+      balance: 5000,
+      checkIn: null,
+      transactions: [],
+    });
+
+    const useCase = RegisterMemberUseCase(mocks);
+
+    await expect(
+      useCase.execute({ member: { name: 'New User', memberId: 'M002' } }),
+    ).rejects.toThrow('Card already registered');
+  });
+
+  it('throws when write verification fails', async () => {
+    const mocks = createMocks();
+    (mocks.silentShieldService.decrypt as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error('Decryption failed');
+    });
+    (mocks.nfcService.writeAndVerify as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: false,
+      error: 'Tag removed',
+    });
+
+    const useCase = RegisterMemberUseCase(mocks);
+
+    await expect(
+      useCase.execute({ member: { name: 'Test', memberId: 'M003' } }),
+    ).rejects.toThrow('Registration failed');
+  });
+
+  it('throws when NFC read fails', async () => {
+    const mocks = createMocks();
+    (mocks.nfcService.readCard as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('NFC read failed'),
+    );
+
+    const useCase = RegisterMemberUseCase(mocks);
+
+    await expect(
+      useCase.execute({ member: { name: 'Test', memberId: 'M004' } }),
+    ).rejects.toThrow('NFC read failed');
+  });
+});

--- a/src/@core/use_case/__tests__/mbc/TopUpBalance.test.ts
+++ b/src/@core/use_case/__tests__/mbc/TopUpBalance.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { CardData } from '@core/services/mbc/models';
+import type { NfcServiceInterface } from '@core/services/mbc/nfc.service';
+import type { CardDataServiceInterface } from '@core/services/mbc/card-data.service';
+import type { SilentShieldServiceInterface } from '@core/services/mbc/silent-shield.service';
+
+import { TopUpBalanceUseCase } from '../../mbc/TopUpBalance';
+
+const REGISTERED_CARD: CardData = {
+  version: 1,
+  member: { name: 'John Doe', memberId: 'M001' },
+  balance: 10000,
+  checkIn: null,
+  transactions: [],
+};
+
+function createMocks(cardData: CardData = REGISTERED_CARD) {
+  const nfcService: NfcServiceInterface = {
+    isAvailable: vi.fn().mockReturnValue(true),
+    requestPermission: vi.fn().mockResolvedValue('granted'),
+    readCard: vi.fn().mockResolvedValue(new Uint8Array([1])),
+    writeCard: vi.fn().mockResolvedValue(undefined),
+    writeAndVerify: vi.fn().mockResolvedValue({ success: true }),
+  };
+
+  const cardDataService: CardDataServiceInterface = {
+    serialize: vi.fn().mockReturnValue(new Uint8Array([10])),
+    deserialize: vi.fn().mockReturnValue(cardData),
+    validate: vi.fn().mockReturnValue({ success: true }),
+    applyRegistration: vi.fn(),
+    applyTopUp: vi.fn().mockImplementation((card, amount) => ({
+      ...card,
+      balance: card.balance + amount,
+    })),
+    applyCheckIn: vi.fn(),
+    applyCheckOut: vi.fn(),
+    appendTransactionLog: vi.fn(),
+  };
+
+  const silentShieldService: SilentShieldServiceInterface = {
+    encrypt: vi.fn().mockReturnValue(new Uint8Array([99])),
+    decrypt: vi.fn().mockReturnValue(new Uint8Array([1])),
+  };
+
+  return { nfcService, cardDataService, silentShieldService };
+}
+
+describe('TopUpBalanceUseCase', () => {
+  it('tops up balance successfully', async () => {
+    const mocks = createMocks();
+    const useCase = TopUpBalanceUseCase(mocks);
+
+    const result = await useCase.execute({ amount: 5000 });
+
+    expect(result.type).toBe('top-up');
+    expect(result.memberName).toBe('John Doe');
+    expect(result.previousBalance).toBe(10000);
+    expect(result.amount).toBe(5000);
+    expect(result.newBalance).toBe(15000);
+  });
+
+  it('rejects zero amount', async () => {
+    const mocks = createMocks();
+    const useCase = TopUpBalanceUseCase(mocks);
+
+    await expect(useCase.execute({ amount: 0 })).rejects.toThrow('positive number');
+  });
+
+  it('rejects negative amount', async () => {
+    const mocks = createMocks();
+    const useCase = TopUpBalanceUseCase(mocks);
+
+    await expect(useCase.execute({ amount: -1000 })).rejects.toThrow('positive number');
+  });
+
+  it('rejects unregistered card', async () => {
+    const unregistered: CardData = {
+      version: 1,
+      member: { name: '', memberId: '' },
+      balance: 0,
+      checkIn: null,
+      transactions: [],
+    };
+    const mocks = createMocks(unregistered);
+    const useCase = TopUpBalanceUseCase(mocks);
+
+    await expect(useCase.execute({ amount: 5000 })).rejects.toThrow('not registered');
+  });
+
+  it('throws when write verification fails', async () => {
+    const mocks = createMocks();
+    (mocks.nfcService.writeAndVerify as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: false,
+      error: 'Connection lost',
+    });
+    const useCase = TopUpBalanceUseCase(mocks);
+
+    await expect(useCase.execute({ amount: 5000 })).rejects.toThrow('Top-up failed');
+  });
+});

--- a/src/@core/use_case/mbc/CheckIn.ts
+++ b/src/@core/use_case/mbc/CheckIn.ts
@@ -1,0 +1,72 @@
+import type { AwilixRegistry } from '@di/container';
+import type { CheckInResult } from '@core/services/mbc/models';
+
+export interface CheckInInput {
+  serviceTypeId: string;
+  serviceTypeName: string;
+  deviceId: string;
+  /** Optional custom timestamp for simulation mode (ISO 8601) */
+  simulationTimestamp?: string;
+}
+
+export interface CheckInUseCaseInterface {
+  execute(input: CheckInInput): Promise<CheckInResult>;
+}
+
+export const CheckInUseCase = (
+  deps: Pick<
+    AwilixRegistry,
+    'nfcService' | 'cardDataService' | 'silentShieldService'
+  >,
+): CheckInUseCaseInterface => {
+  const { nfcService, cardDataService, silentShieldService } = deps;
+
+  const execute = async (input: CheckInInput): Promise<CheckInResult> => {
+    // Step 1: Read card → decrypt → deserialize
+    const rawEncrypted = await nfcService.readCard();
+    const decrypted = silentShieldService.decrypt(rawEncrypted);
+    const cardData = cardDataService.deserialize(decrypted);
+
+    // Step 2: Validate card is registered
+    if (!cardData.member.name || !cardData.member.memberId) {
+      throw new Error('Card is not registered. Please register at The Station first.');
+    }
+
+    // Step 3: Validate no active check-in (double tap-in prevention)
+    if (cardData.checkIn !== null) {
+      throw new Error(
+        'Member already checked in. Cannot check in again until check-out is completed.',
+      );
+    }
+
+    // Step 4: Determine timestamp (real or simulation)
+    const timestamp = input.simulationTimestamp ?? new Date().toISOString();
+
+    // Step 5: Apply check-in
+    const updatedCard = cardDataService.applyCheckIn(
+      cardData,
+      input.serviceTypeId,
+      input.deviceId,
+      timestamp,
+    );
+
+    // Step 6: Serialize → encrypt → write with verify
+    const serialized = cardDataService.serialize(updatedCard);
+    const encrypted = silentShieldService.encrypt(serialized);
+    const writeResult = await nfcService.writeAndVerify(encrypted);
+
+    if (!writeResult.success) {
+      throw new Error(
+        `Check-in failed: write verification error — ${writeResult.error}`,
+      );
+    }
+
+    return {
+      memberName: cardData.member.name,
+      entryTime: timestamp,
+      serviceTypeName: input.serviceTypeName,
+    };
+  };
+
+  return { execute };
+};

--- a/src/@core/use_case/mbc/CheckOut.ts
+++ b/src/@core/use_case/mbc/CheckOut.ts
@@ -1,0 +1,132 @@
+import type { AwilixRegistry } from '@di/container';
+import type { CheckOutResult } from '@core/services/mbc/models';
+import { formatDuration } from '@utils/helpers/mbc.helper';
+
+export interface CheckOutInput {
+  currentDeviceId: string;
+}
+
+export interface CheckOutUseCaseInterface {
+  execute(input: CheckOutInput): Promise<CheckOutResult>;
+}
+
+export const CheckOutUseCase = (
+  deps: Pick<
+    AwilixRegistry,
+    | 'nfcService'
+    | 'cardDataService'
+    | 'silentShieldService'
+    | 'pricingService'
+    | 'serviceRegistryService'
+  >,
+): CheckOutUseCaseInterface => {
+  const {
+    nfcService,
+    cardDataService,
+    silentShieldService,
+    pricingService,
+    serviceRegistryService,
+  } = deps;
+
+  const execute = async (input: CheckOutInput): Promise<CheckOutResult> => {
+    // Step 1: Read card → decrypt → deserialize
+    const rawEncrypted = await nfcService.readCard();
+    const decrypted = silentShieldService.decrypt(rawEncrypted);
+    const cardData = cardDataService.deserialize(decrypted);
+
+    // Step 2: Validate active check-in exists (double tap-out prevention)
+    if (cardData.checkIn === null) {
+      throw new Error(
+        'Member has not checked in. Cannot process check-out without an active check-in session.',
+      );
+    }
+
+    // Step 3: Validate device ID match
+    if (cardData.checkIn.deviceId !== input.currentDeviceId) {
+      throw new Error(
+        'Device mismatch. This member checked in on a different device. ' +
+          'Please return to the original check-in device to process check-out.',
+      );
+    }
+
+    // Step 4: Lookup service type from registry
+    const serviceType = await serviceRegistryService.getById(
+      cardData.checkIn.serviceTypeId,
+    );
+    if (!serviceType) {
+      throw new Error(
+        `Service type "${cardData.checkIn.serviceTypeId}" not found in registry. ` +
+          'Please reconfigure service types at The Station.',
+      );
+    }
+
+    // Step 5: Calculate fee
+    const exitTime = new Date().toISOString();
+    const feeResult = pricingService.calculateFee(
+      serviceType.pricing,
+      cardData.checkIn.timestamp,
+      exitTime,
+    );
+
+    // Step 6: Validate sufficient balance
+    if (feeResult.fee > cardData.balance) {
+      const shortage = feeResult.fee - cardData.balance;
+      throw new Error(
+        `Insufficient balance. Fee: Rp ${feeResult.fee.toLocaleString('id-ID')}, ` +
+          `Balance: Rp ${cardData.balance.toLocaleString('id-ID')}, ` +
+          `Shortage: Rp ${shortage.toLocaleString('id-ID')}. ` +
+          'Please top-up at The Station.',
+      );
+    }
+
+    // Step 7: Snapshot current state (for potential rollback)
+    const snapshot = cardDataService.serialize(cardData);
+
+    // Step 8: Apply check-out (deduct fee, clear check-in, append transaction log)
+    const updatedCard = cardDataService.applyCheckOut(
+      cardData,
+      feeResult.fee,
+      serviceType.activityType,
+      serviceType.id,
+      exitTime,
+    );
+
+    // Step 9: Serialize → encrypt → write with verify
+    const serialized = cardDataService.serialize(updatedCard);
+    const encrypted = silentShieldService.encrypt(serialized);
+    const writeResult = await nfcService.writeAndVerify(encrypted);
+
+    if (!writeResult.success) {
+      // Attempt rollback: restore snapshot
+      try {
+        const snapshotEncrypted = silentShieldService.encrypt(snapshot);
+        await nfcService.writeCard(snapshotEncrypted);
+      } catch {
+        // Rollback failed — card may be in inconsistent state
+        throw new Error(
+          'CRITICAL: Check-out write failed AND rollback failed. ' +
+            'Card may be in an inconsistent state. Please contact support.',
+        );
+      }
+      throw new Error(
+        `Check-out failed: write verification error — ${writeResult.error}. ` +
+          'Card has been rolled back to pre-checkout state.',
+      );
+    }
+
+    // Step 10: Calculate duration for display
+    const duration = formatDuration(cardData.checkIn.timestamp, exitTime);
+
+    return {
+      serviceTypeName: serviceType.displayName,
+      entryTime: cardData.checkIn.timestamp,
+      exitTime,
+      duration,
+      fee: feeResult.fee,
+      remainingBalance: updatedCard.balance,
+      feeBreakdown: feeResult,
+    };
+  };
+
+  return { execute };
+};

--- a/src/@core/use_case/mbc/ManageServiceRegistry.ts
+++ b/src/@core/use_case/mbc/ManageServiceRegistry.ts
@@ -1,0 +1,55 @@
+import type { AwilixRegistry } from '@di/container';
+import type { ServiceType } from '@core/services/mbc/models';
+
+export interface ManageServiceRegistryUseCaseInterface {
+  getAll(): Promise<ServiceType[]>;
+  add(serviceType: ServiceType): Promise<void>;
+  update(id: string, updates: Partial<Omit<ServiceType, 'id'>>): Promise<void>;
+  remove(id: string): Promise<void>;
+  initializeDefaults(): Promise<void>;
+}
+
+export const ManageServiceRegistryUseCase = (
+  deps: Pick<AwilixRegistry, 'serviceRegistryService'>,
+): ManageServiceRegistryUseCaseInterface => {
+  const { serviceRegistryService } = deps;
+
+  let initialized = false;
+
+  const ensureInitialized = async (): Promise<void> => {
+    if (!initialized) {
+      await serviceRegistryService.initializeDefaults();
+      initialized = true;
+    }
+  };
+
+  const getAll = async (): Promise<ServiceType[]> => {
+    await ensureInitialized();
+    return serviceRegistryService.getAll();
+  };
+
+  const add = async (serviceType: ServiceType): Promise<void> => {
+    await ensureInitialized();
+    return serviceRegistryService.add(serviceType);
+  };
+
+  const update = async (
+    id: string,
+    updates: Partial<Omit<ServiceType, 'id'>>,
+  ): Promise<void> => {
+    await ensureInitialized();
+    return serviceRegistryService.update(id, updates);
+  };
+
+  const remove = async (id: string): Promise<void> => {
+    await ensureInitialized();
+    return serviceRegistryService.remove(id);
+  };
+
+  const initializeDefaults = async (): Promise<void> => {
+    await serviceRegistryService.initializeDefaults();
+    initialized = true;
+  };
+
+  return { getAll, add, update, remove, initializeDefaults };
+};

--- a/src/@core/use_case/mbc/ManualCalculation.ts
+++ b/src/@core/use_case/mbc/ManualCalculation.ts
@@ -1,0 +1,50 @@
+import type { AwilixRegistry } from '@di/container';
+import type { FeeResult } from '@core/services/mbc/models';
+
+export interface ManualCalculationInput {
+  checkInTimestamp: string;
+  serviceTypeId: string;
+}
+
+export interface ManualCalculationUseCaseInterface {
+  execute(input: ManualCalculationInput): Promise<FeeResult>;
+}
+
+export const ManualCalculationUseCase = (
+  deps: Pick<AwilixRegistry, 'pricingService' | 'serviceRegistryService'>,
+): ManualCalculationUseCaseInterface => {
+  const { pricingService, serviceRegistryService } = deps;
+
+  const execute = async (
+    input: ManualCalculationInput,
+  ): Promise<FeeResult> => {
+    // Step 1: Lookup service type from registry
+    const serviceType = await serviceRegistryService.getById(
+      input.serviceTypeId,
+    );
+    if (!serviceType) {
+      throw new Error(
+        `Service type "${input.serviceTypeId}" not found in registry. ` +
+          'Please configure service types at The Station.',
+      );
+    }
+
+    // Step 2: Validate check-in timestamp
+    const checkInDate = new Date(input.checkInTimestamp);
+    if (isNaN(checkInDate.getTime())) {
+      throw new Error('Invalid check-in timestamp format. Expected ISO 8601.');
+    }
+
+    // Step 3: Calculate fee using current time as check-out
+    const checkOutTime = new Date().toISOString();
+    const feeResult = pricingService.calculateFee(
+      serviceType.pricing,
+      input.checkInTimestamp,
+      checkOutTime,
+    );
+
+    return feeResult;
+  };
+
+  return { execute };
+};

--- a/src/@core/use_case/mbc/ReadCard.ts
+++ b/src/@core/use_case/mbc/ReadCard.ts
@@ -1,0 +1,35 @@
+import type { AwilixRegistry } from '@di/container';
+import type { CardData } from '@core/services/mbc/models';
+
+export interface ReadCardUseCaseInterface {
+  execute(): Promise<CardData>;
+}
+
+export const ReadCardUseCase = (
+  deps: Pick<
+    AwilixRegistry,
+    'nfcService' | 'cardDataService' | 'silentShieldService'
+  >,
+): ReadCardUseCaseInterface => {
+  const { nfcService, cardDataService, silentShieldService } = deps;
+
+  const execute = async (): Promise<CardData> => {
+    // Step 1: Read card
+    const rawEncrypted = await nfcService.readCard();
+
+    // Step 2: Decrypt
+    const decrypted = silentShieldService.decrypt(rawEncrypted);
+
+    // Step 3: Deserialize (includes Zod validation)
+    const cardData = cardDataService.deserialize(decrypted);
+
+    // Step 4: Validate card is registered
+    if (!cardData.member.name || !cardData.member.memberId) {
+      throw new Error('Card is not registered or contains invalid data.');
+    }
+
+    return cardData;
+  };
+
+  return { execute };
+};

--- a/src/@core/use_case/mbc/RegisterMember.ts
+++ b/src/@core/use_case/mbc/RegisterMember.ts
@@ -1,0 +1,79 @@
+import type { AwilixRegistry } from '@di/container';
+import type { MemberIdentity, OperationResult } from '@core/services/mbc/models';
+
+export interface RegisterMemberInput {
+  member: MemberIdentity;
+}
+
+export interface RegisterMemberUseCaseInterface {
+  execute(input: RegisterMemberInput): Promise<OperationResult>;
+}
+
+export const RegisterMemberUseCase = (
+  deps: Pick<
+    AwilixRegistry,
+    'nfcService' | 'cardDataService' | 'silentShieldService'
+  >,
+): RegisterMemberUseCaseInterface => {
+  const { nfcService, cardDataService, silentShieldService } = deps;
+
+  const execute = async (input: RegisterMemberInput): Promise<OperationResult> => {
+    // Step 1: Read card
+    const rawEncrypted = await nfcService.readCard();
+
+    // Step 2: Try to decrypt and deserialize to check if card already has data
+    try {
+      const decrypted = silentShieldService.decrypt(rawEncrypted);
+      const existingCard = cardDataService.deserialize(decrypted);
+
+      // If we get here, card already has valid member data
+      if (existingCard.member.name.length > 0) {
+        throw new Error(
+          'Card already registered. This card belongs to: ' +
+            existingCard.member.name,
+        );
+      }
+    } catch (error: unknown) {
+      // If decryption/deserialization fails, card is blank — proceed with registration
+      if (
+        error instanceof Error &&
+        error.message.startsWith('Card already registered')
+      ) {
+        throw error;
+      }
+      // Otherwise, card is blank or corrupted — safe to register
+    }
+
+    // Step 3: Create fresh card data with registration
+    const blankCard = {
+      version: 1,
+      member: { name: '', memberId: '' },
+      balance: 0,
+      checkIn: null,
+      transactions: [],
+    };
+    const registeredCard = cardDataService.applyRegistration(
+      blankCard,
+      input.member,
+    );
+
+    // Step 4: Serialize → encrypt → write with verify
+    const serialized = cardDataService.serialize(registeredCard);
+    const encrypted = silentShieldService.encrypt(serialized);
+    const writeResult = await nfcService.writeAndVerify(encrypted);
+
+    if (!writeResult.success) {
+      throw new Error(
+        `Registration failed: write verification error — ${writeResult.error}`,
+      );
+    }
+
+    return {
+      type: 'registration',
+      memberName: input.member.name,
+      newBalance: 0,
+    };
+  };
+
+  return { execute };
+};

--- a/src/@core/use_case/mbc/TopUpBalance.ts
+++ b/src/@core/use_case/mbc/TopUpBalance.ts
@@ -1,0 +1,61 @@
+import type { AwilixRegistry } from '@di/container';
+import type { OperationResult } from '@core/services/mbc/models';
+
+export interface TopUpBalanceInput {
+  amount: number;
+}
+
+export interface TopUpBalanceUseCaseInterface {
+  execute(input: TopUpBalanceInput): Promise<OperationResult>;
+}
+
+export const TopUpBalanceUseCase = (
+  deps: Pick<
+    AwilixRegistry,
+    'nfcService' | 'cardDataService' | 'silentShieldService'
+  >,
+): TopUpBalanceUseCaseInterface => {
+  const { nfcService, cardDataService, silentShieldService } = deps;
+
+  const execute = async (input: TopUpBalanceInput): Promise<OperationResult> => {
+    if (input.amount <= 0) {
+      throw new Error('Top-up amount must be a positive number');
+    }
+
+    // Step 1: Read card → decrypt → deserialize
+    const rawEncrypted = await nfcService.readCard();
+    const decrypted = silentShieldService.decrypt(rawEncrypted);
+    const cardData = cardDataService.deserialize(decrypted);
+
+    // Step 2: Validate card is registered
+    if (!cardData.member.name || !cardData.member.memberId) {
+      throw new Error('Card is not registered. Please register at The Station first.');
+    }
+
+    const previousBalance = cardData.balance;
+
+    // Step 3: Apply top-up (also appends transaction log)
+    const updatedCard = cardDataService.applyTopUp(cardData, input.amount);
+
+    // Step 4: Serialize → encrypt → write with verify
+    const serialized = cardDataService.serialize(updatedCard);
+    const encrypted = silentShieldService.encrypt(serialized);
+    const writeResult = await nfcService.writeAndVerify(encrypted);
+
+    if (!writeResult.success) {
+      throw new Error(
+        `Top-up failed: write verification error — ${writeResult.error}`,
+      );
+    }
+
+    return {
+      type: 'top-up',
+      memberName: cardData.member.name,
+      previousBalance,
+      amount: input.amount,
+      newBalance: updatedCard.balance,
+    };
+  };
+
+  return { execute };
+};

--- a/src/infrastructure/di/container.ts
+++ b/src/infrastructure/di/container.ts
@@ -39,6 +39,10 @@ import {
   MbcServiceContainerInterface,
   registerMbcServiceModules,
 } from '@di/registry/mbcServiceContainer';
+import {
+  MbcUseCaseContainerInterface,
+  registerMbcUseCaseModules,
+} from '@di/registry/mbcUseCaseContainer';
 
 const container = createContainer<AwilixRegistry>();
 
@@ -48,6 +52,7 @@ registerServiceModules(container);
 registerMbcServiceModules(container);
 registerTanstackModule(container);
 registerUseCaseModules(container);
+registerMbcUseCaseModules(container);
 registerLibraryModule(container);
 registerControllerModules(container);
 registerReactModules(container);
@@ -60,6 +65,7 @@ export type AwilixRegistry = ControllerContainerInterface &
   LibraryContainerInterface &
   MbcProtocolContainerInterface &
   MbcServiceContainerInterface &
+  MbcUseCaseContainerInterface &
   ProtocolContainerInterface &
   ReactContainerInterface &
   ServiceContainerInterface &

--- a/src/infrastructure/di/registry/mbcUseCaseContainer.ts
+++ b/src/infrastructure/di/registry/mbcUseCaseContainer.ts
@@ -1,0 +1,40 @@
+import type { AwilixContainer } from 'awilix';
+import { asFunction } from 'awilix';
+
+import type { RegisterMemberUseCaseInterface } from '@core/use_case/mbc/RegisterMember';
+import type { TopUpBalanceUseCaseInterface } from '@core/use_case/mbc/TopUpBalance';
+import type { CheckInUseCaseInterface } from '@core/use_case/mbc/CheckIn';
+import type { CheckOutUseCaseInterface } from '@core/use_case/mbc/CheckOut';
+import type { ReadCardUseCaseInterface } from '@core/use_case/mbc/ReadCard';
+import type { ManualCalculationUseCaseInterface } from '@core/use_case/mbc/ManualCalculation';
+import type { ManageServiceRegistryUseCaseInterface } from '@core/use_case/mbc/ManageServiceRegistry';
+
+import { RegisterMemberUseCase } from '@core/use_case/mbc/RegisterMember';
+import { TopUpBalanceUseCase } from '@core/use_case/mbc/TopUpBalance';
+import { CheckInUseCase } from '@core/use_case/mbc/CheckIn';
+import { CheckOutUseCase } from '@core/use_case/mbc/CheckOut';
+import { ReadCardUseCase } from '@core/use_case/mbc/ReadCard';
+import { ManualCalculationUseCase } from '@core/use_case/mbc/ManualCalculation';
+import { ManageServiceRegistryUseCase } from '@core/use_case/mbc/ManageServiceRegistry';
+
+export function registerMbcUseCaseModules(container: AwilixContainer) {
+  container.register({
+    registerMemberUseCase: asFunction(RegisterMemberUseCase),
+    topUpBalanceUseCase: asFunction(TopUpBalanceUseCase),
+    checkInUseCase: asFunction(CheckInUseCase),
+    checkOutUseCase: asFunction(CheckOutUseCase),
+    readCardUseCase: asFunction(ReadCardUseCase),
+    manualCalculationUseCase: asFunction(ManualCalculationUseCase),
+    manageServiceRegistryUseCase: asFunction(ManageServiceRegistryUseCase).singleton(),
+  });
+}
+
+export interface MbcUseCaseContainerInterface {
+  registerMemberUseCase: RegisterMemberUseCaseInterface;
+  topUpBalanceUseCase: TopUpBalanceUseCaseInterface;
+  checkInUseCase: CheckInUseCaseInterface;
+  checkOutUseCase: CheckOutUseCaseInterface;
+  readCardUseCase: ReadCardUseCaseInterface;
+  manualCalculationUseCase: ManualCalculationUseCaseInterface;
+  manageServiceRegistryUseCase: ManageServiceRegistryUseCaseInterface;
+}


### PR DESCRIPTION
## Phase 4: Layer 4 — Use Cases

### Changes
- **RegisterMember** — Blank card detection, atomic write with verify
- **TopUpBalance** — Amount validation, balance update, transaction log
- **CheckIn** — Double tap-in prevention, simulation mode support
- **CheckOut** — Device binding, fee calculation, snapshot + rollback on failure
- **ReadCard** — Read-only, no writes, corruption detection
- **ManualCalculation** — Pure fee calculation without NFC
- **ManageServiceRegistry** — CRUD delegation with lazy initialization
- **DI wiring** — mbcUseCaseContainer with 7 use cases

### Testing
- 97 tests total (36 new + 61 existing), all passing
- 7 new test files for use cases
- Covers: positive, negative, edge cases, rollback scenarios

Closes #15, closes #16, closes #17, closes #18, closes #19, closes #20, closes #21, closes #22