### PR TITLE
refactor(mbc): flatten route structure from /mbc/* to root /*

### DIFF
--- a/src/presentation/pages/(mbc)/MbcRolePicker/index.tsx
+++ b/src/presentation/pages/(mbc)/MbcRolePicker/index.tsx
@@ -21,7 +21,7 @@ const MbcRolePicker: FC = () => {
             isActive={ctrl.activeRole === role.id}
             onSelect={() => {
               ctrl.onSelectRole(role.id);
-              navigate({ to: `/mbc/${role.id}` });
+              navigate({ to: `/${role.id}` });
             }}
           />
         ))}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,107 +9,106 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as TerminalRouteImport } from './routes/terminal'
+import { Route as StationRouteImport } from './routes/station'
+import { Route as ScoutRouteImport } from './routes/scout'
+import { Route as GateRouteImport } from './routes/gate'
 import { Route as IndexRouteImport } from './routes/index'
-import { Route as MbcIndexRouteImport } from './routes/mbc/index'
-import { Route as MbcTerminalRouteImport } from './routes/mbc/terminal'
-import { Route as MbcStationRouteImport } from './routes/mbc/station'
-import { Route as MbcScoutRouteImport } from './routes/mbc/scout'
-import { Route as MbcGateRouteImport } from './routes/mbc/gate'
 
+const TerminalRoute = TerminalRouteImport.update({
+  id: '/terminal',
+  path: '/terminal',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const StationRoute = StationRouteImport.update({
+  id: '/station',
+  path: '/station',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ScoutRoute = ScoutRouteImport.update({
+  id: '/scout',
+  path: '/scout',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const GateRoute = GateRouteImport.update({
+  id: '/gate',
+  path: '/gate',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
-const MbcIndexRoute = MbcIndexRouteImport.update({
-  id: '/mbc/',
-  path: '/mbc/',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const MbcTerminalRoute = MbcTerminalRouteImport.update({
-  id: '/mbc/terminal',
-  path: '/mbc/terminal',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const MbcStationRoute = MbcStationRouteImport.update({
-  id: '/mbc/station',
-  path: '/mbc/station',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const MbcScoutRoute = MbcScoutRouteImport.update({
-  id: '/mbc/scout',
-  path: '/mbc/scout',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const MbcGateRoute = MbcGateRouteImport.update({
-  id: '/mbc/gate',
-  path: '/mbc/gate',
-  getParentRoute: () => rootRouteImport,
-} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
-  '/mbc/gate': typeof MbcGateRoute
-  '/mbc/scout': typeof MbcScoutRoute
-  '/mbc/station': typeof MbcStationRoute
-  '/mbc/terminal': typeof MbcTerminalRoute
-  '/mbc/': typeof MbcIndexRoute
+  '/gate': typeof GateRoute
+  '/scout': typeof ScoutRoute
+  '/station': typeof StationRoute
+  '/terminal': typeof TerminalRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
-  '/mbc/gate': typeof MbcGateRoute
-  '/mbc/scout': typeof MbcScoutRoute
-  '/mbc/station': typeof MbcStationRoute
-  '/mbc/terminal': typeof MbcTerminalRoute
-  '/mbc': typeof MbcIndexRoute
+  '/gate': typeof GateRoute
+  '/scout': typeof ScoutRoute
+  '/station': typeof StationRoute
+  '/terminal': typeof TerminalRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
-  '/mbc/gate': typeof MbcGateRoute
-  '/mbc/scout': typeof MbcScoutRoute
-  '/mbc/station': typeof MbcStationRoute
-  '/mbc/terminal': typeof MbcTerminalRoute
-  '/mbc/': typeof MbcIndexRoute
+  '/gate': typeof GateRoute
+  '/scout': typeof ScoutRoute
+  '/station': typeof StationRoute
+  '/terminal': typeof TerminalRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths:
-    | '/'
-    | '/mbc/gate'
-    | '/mbc/scout'
-    | '/mbc/station'
-    | '/mbc/terminal'
-    | '/mbc/'
+  fullPaths: '/' | '/gate' | '/scout' | '/station' | '/terminal'
   fileRoutesByTo: FileRoutesByTo
-  to:
-    | '/'
-    | '/mbc/gate'
-    | '/mbc/scout'
-    | '/mbc/station'
-    | '/mbc/terminal'
-    | '/mbc'
-  id:
-    | '__root__'
-    | '/'
-    | '/mbc/gate'
-    | '/mbc/scout'
-    | '/mbc/station'
-    | '/mbc/terminal'
-    | '/mbc/'
+  to: '/' | '/gate' | '/scout' | '/station' | '/terminal'
+  id: '__root__' | '/' | '/gate' | '/scout' | '/station' | '/terminal'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
-  MbcGateRoute: typeof MbcGateRoute
-  MbcScoutRoute: typeof MbcScoutRoute
-  MbcStationRoute: typeof MbcStationRoute
-  MbcTerminalRoute: typeof MbcTerminalRoute
-  MbcIndexRoute: typeof MbcIndexRoute
+  GateRoute: typeof GateRoute
+  ScoutRoute: typeof ScoutRoute
+  StationRoute: typeof StationRoute
+  TerminalRoute: typeof TerminalRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/terminal': {
+      id: '/terminal'
+      path: '/terminal'
+      fullPath: '/terminal'
+      preLoaderRoute: typeof TerminalRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/station': {
+      id: '/station'
+      path: '/station'
+      fullPath: '/station'
+      preLoaderRoute: typeof StationRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/scout': {
+      id: '/scout'
+      path: '/scout'
+      fullPath: '/scout'
+      preLoaderRoute: typeof ScoutRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/gate': {
+      id: '/gate'
+      path: '/gate'
+      fullPath: '/gate'
+      preLoaderRoute: typeof GateRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -117,51 +116,15 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/mbc/': {
-      id: '/mbc/'
-      path: '/mbc'
-      fullPath: '/mbc/'
-      preLoaderRoute: typeof MbcIndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/mbc/terminal': {
-      id: '/mbc/terminal'
-      path: '/mbc/terminal'
-      fullPath: '/mbc/terminal'
-      preLoaderRoute: typeof MbcTerminalRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/mbc/station': {
-      id: '/mbc/station'
-      path: '/mbc/station'
-      fullPath: '/mbc/station'
-      preLoaderRoute: typeof MbcStationRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/mbc/scout': {
-      id: '/mbc/scout'
-      path: '/mbc/scout'
-      fullPath: '/mbc/scout'
-      preLoaderRoute: typeof MbcScoutRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/mbc/gate': {
-      id: '/mbc/gate'
-      path: '/mbc/gate'
-      fullPath: '/mbc/gate'
-      preLoaderRoute: typeof MbcGateRouteImport
-      parentRoute: typeof rootRouteImport
-    }
   }
 }
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
-  MbcGateRoute: MbcGateRoute,
-  MbcScoutRoute: MbcScoutRoute,
-  MbcStationRoute: MbcStationRoute,
-  MbcTerminalRoute: MbcTerminalRoute,
-  MbcIndexRoute: MbcIndexRoute,
+  GateRoute: GateRoute,
+  ScoutRoute: ScoutRoute,
+  StationRoute: StationRoute,
+  TerminalRoute: TerminalRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/gate.tsx
+++ b/src/routes/gate.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router';
 import MbcGate from '@pages/(mbc)/MbcGate';
 
-export const Route = createFileRoute('/mbc/gate')({
+export const Route = createFileRoute('/gate')({
   component: MbcGate,
 });

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,10 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router';
+import MbcRolePicker from '@pages/(mbc)/MbcRolePicker';
 
 export const Route = createFileRoute('/')({
-  component: () => (
-    <div>
-      <h1>MyTelkomsel MBC</h1>
-      <p>Membership Benefit Card</p>
-    </div>
-  ),
+  component: MbcRolePicker,
 });

--- a/src/routes/mbc/index.tsx
+++ b/src/routes/mbc/index.tsx
@@ -1,6 +1,0 @@
-import { createFileRoute } from '@tanstack/react-router';
-import MbcRolePicker from '@pages/(mbc)/MbcRolePicker';
-
-export const Route = createFileRoute('/mbc/')({
-  component: MbcRolePicker,
-});

--- a/src/routes/scout.tsx
+++ b/src/routes/scout.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router';
 import MbcScout from '@pages/(mbc)/MbcScout';
 
-export const Route = createFileRoute('/mbc/scout')({
+export const Route = createFileRoute('/scout')({
   component: MbcScout,
 });

--- a/src/routes/station.tsx
+++ b/src/routes/station.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router';
 import MbcStation from '@pages/(mbc)/MbcStation';
 
-export const Route = createFileRoute('/mbc/station')({
+export const Route = createFileRoute('/station')({
   component: MbcStation,
 });

--- a/src/routes/terminal.tsx
+++ b/src/routes/terminal.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router';
 import MbcTerminal from '@pages/(mbc)/MbcTerminal';
 
-export const Route = createFileRoute('/mbc/terminal')({
+export const Route = createFileRoute('/terminal')({
   component: MbcTerminal,
 });


### PR DESCRIPTION
## Changes

Move all MBC routes from `/mbc/*` prefix to root level `/*` so the app renders directly at the base URL.

| Before | After |
|--------|-------|
| `/` → placeholder | `/` → Role Picker |
| `/mbc` → Role Picker | removed |
| `/mbc/station` | `/station` |
| `/mbc/gate` | `/gate` |
| `/mbc/terminal` | `/terminal` |
| `/mbc/scout` | `/scout` |

### Why
MBC is the only feature in this app. The `/mbc` prefix added unnecessary nesting with no benefit.

### Testing
- `npm run build` ✅ zero errors
- `npx vitest --run` ✅ 119 passed, 0 failures
- TanStack Router route tree regenerated

Closes #47