### PR TITLE
refactor(mbc): CSS Modules with BEM @apply

### DIFF
--- a/.kiro/specs/membership-benefit-card/tasks.md
+++ b/.kiro/specs/membership-benefit-card/tasks.md
@@ -547,6 +547,71 @@ This plan implements the MBC feature following a strict bottom-up build order: d
     - No `any` types introduced
     - Clean Architecture layer boundaries maintained
 
+- [x] 21. Refactor — CSS Modules with Tailwind @apply
+  - **Assigned:** @developer
+  - **Steering:** `.kiro/steering/styling-rules.md`
+  - **Scope:** Move all inline Tailwind utility classes from JSX to co-located CSS Module files using `@apply`
+
+  - [x] 21.1 Refactor presentation components (10 files)
+    - `NfcTapPrompt/index.tsx` → + `nfc-tap-prompt.module.css`
+    - `FeeBreakdown/index.tsx` → + `fee-breakdown.module.css`
+    - `BalanceDisplay/index.tsx` → + `balance-display.module.css`
+    - `TransactionLogList/index.tsx` → + `transaction-log-list.module.css`
+    - `ServiceTypeSelector/index.tsx` → + `service-type-selector.module.css`
+    - `ServiceTypeForm/index.tsx` → + `service-type-form.module.css`
+    - `CardInfoDisplay/index.tsx` → + `card-info-display.module.css`
+    - `SimulationBanner/index.tsx` → + `simulation-banner.module.css`
+    - `ManualCalcForm/index.tsx` → + `manual-calc-form.module.css`
+    - `RoleCard/index.tsx` → + `role-card.module.css`
+
+  - [x] 21.2 Refactor pages (5 files)
+    - `MbcRolePicker/index.tsx` → + `mbc-role-picker.module.css`
+    - `MbcStation/index.tsx` → + `mbc-station.module.css`
+    - `MbcGate/index.tsx` → + `mbc-gate.module.css`
+    - `MbcTerminal/index.tsx` → + `mbc-terminal.module.css`
+    - `MbcScout/index.tsx` → + `mbc-scout.module.css`
+
+  - [x] 21.3 Update steering document
+    - Updated `.kiro/steering/styling-rules.md` with CSS Modules + `@apply` conventions
+    - All CSS Module files include `@reference "tailwindcss"` directive (Tailwind v4 requirement)
+    - Conditional classes use template literals with `styles.*` references
+
+  - [x] 21.4 Verification checkpoint
+    - Build: ✅ Pass (`npm run build` — zero errors)
+    - Tests: ✅ Pass (`npx vitest --run` — 119 passed, 18 test files, zero failures)
+    - 15 CSS Module files created, 15 TSX files updated
+    - No inline Tailwind utilities remain in JSX `className` props
+
+- [ ] 22. Refactor — Proactive NFC Capability Detection
+  - **Assigned:** @developer
+  - **Issue:** #50
+  - **Scope:** NFC-dependent pages check Web NFC capability on mount, display inline notice when unsupported
+
+  - [ ] 22.1 Add NFC capability check to controllers
+    - Update `station.controller`, `gate.controller`, `terminal.controller`, `scout.controller`
+    - Add `nfcCapability: NfcCapabilityStatus` state checked on mount via `nfcService.isAvailable()`
+    - States: `supported`, `unsupported`, `permission_denied`, `permission_pending`, `checking`
+    - _Requirements: 22.1, 22.2, 22.3_
+
+  - [ ] 22.2 Create NfcCapabilityNotice component
+    - Create `src/presentation/components/mbc/NfcCapabilityNotice/index.tsx` + `nfc-capability-notice.module.css`
+    - Props: `status: NfcCapabilityStatus`
+    - Render inline warning/error notice with explanation per status
+    - Use CSS Modules + `@apply` per styling-rules steering
+    - _Requirements: 22.2, 22.3, 2.2_
+
+  - [ ] 22.3 Update pages to conditionally render NFC UI
+    - `MbcStation` — gate registration/top-up tabs behind capability check, config tab always available
+    - `MbcGate` — replace NFC area with notice when unsupported
+    - `MbcTerminal` — replace NFC area with notice, keep Manual Calc available
+    - `MbcScout` — replace NFC area with notice
+    - _Requirements: 22.4, 22.5_
+
+  - [ ] 22.4 Verification checkpoint
+    - Build passes, tests pass
+    - NFC unsupported notice visible on desktop Chrome (no Web NFC)
+    - Manual Calculation still works on Terminal when NFC unsupported
+
 ## Notes
 
 - Tasks marked with `*` are optional and can be skipped for faster MVP

--- a/.kiro/steering/styling-rules.md
+++ b/.kiro/steering/styling-rules.md
@@ -1,0 +1,213 @@
+---
+inclusion: fileMatch
+fileMatchPattern: ['**/*.tsx', '**/*.css', '**/*.module.css', 'tailwind.config.ts', 'postcss.config.ts']
+---
+
+# Styling Rules
+
+## Core Principle
+
+**All styling must live in CSS files using Tailwind `@apply`.** Do not write Tailwind utility classes directly in JSX `className` props. Components reference semantic CSS class names; the CSS file composes them from Tailwind utilities via `@apply`.
+
+## Naming Convention — SMACSS + BEM (kebab-case)
+
+All CSS class names use **kebab-case** following BEM (Block Element Modifier) methodology adapted with SMACSS categories.
+
+### BEM Structure
+
+```
+.block {}                    /* Block: component root */
+.block__element {}           /* Element: child of block */
+.block--modifier {}          /* Modifier: variation of block */
+.block__element--modifier {} /* Element with modifier */
+```
+
+### Block Name = Component Name (kebab-case)
+
+The BEM block name **must match the component name** converted to kebab-case:
+
+| Component | Block Name | CSS Module File |
+|-----------|-----------|-----------------|
+| `BalanceDisplay` | `balance-display` | `balance-display.module.css` |
+| `FeeBreakdown` | `fee-breakdown` | `fee-breakdown.module.css` |
+| `NfcTapPrompt` | `nfc-tap-prompt` | `nfc-tap-prompt.module.css` |
+| `MbcStation` | `mbc-station` | `mbc-station.module.css` |
+| `ServiceTypeForm` | `service-type-form` | `service-type-form.module.css` |
+
+### Examples
+
+```css
+/* balance-display.module.css */
+@reference "tailwindcss";
+
+.balance-display {
+  @apply rounded-lg bg-blue-50 p-4;
+}
+
+.balance-display__label {
+  @apply text-sm text-gray-600;
+}
+
+.balance-display__amount {
+  @apply text-2xl font-bold text-blue-700;
+}
+
+.balance-display__change-row {
+  @apply mt-2 text-sm text-gray-500;
+}
+
+.balance-display__change--positive {
+  @apply text-green-600;
+}
+
+.balance-display__change--negative {
+  @apply text-red-600;
+}
+```
+
+```tsx
+/* BalanceDisplay/index.tsx */
+import styles from './balance-display.module.css';
+
+<div className={styles['balance-display']}>
+  <p className={styles['balance-display__label']}>Saldo</p>
+  <p className={styles['balance-display__amount']}>{formatIDR(balance)}</p>
+  <span className={
+    amount >= 0
+      ? styles['balance-display__change--positive']
+      : styles['balance-display__change--negative']
+  }>
+    {formatIDR(amount)}
+  </span>
+</div>
+```
+
+### SMACSS Categories
+
+Organize classes within each CSS Module file following SMACSS order:
+
+1. **Base** — Root element of the component (the BEM block)
+2. **Layout** — Structural containers, grids, flex wrappers (`__header`, `__body`, `__footer`, `__grid`)
+3. **Module** — Reusable child elements (`__label`, `__input`, `__button`, `__icon`)
+4. **State** — Dynamic states (`--active`, `--disabled`, `--error`, `--success`, `--loading`)
+5. **Theme** — Color/visual variations (`--primary`, `--secondary`, `--warning`)
+
+### Naming Rules Summary
+
+| Rule | Example | Anti-pattern |
+|------|---------|-------------|
+| Block = component kebab-case | `.fee-breakdown` | `.feeBreakdown`, `.FeeBreakdown` |
+| Element uses `__` | `.fee-breakdown__label` | `.fee-breakdown-label`, `.feeBreakdownLabel` |
+| Modifier uses `--` | `.fee-breakdown--compact` | `.fee-breakdown-compact`, `.feeBreakdownCompact` |
+| Multi-word kebab-case | `.service-type-form__rate-input` | `.serviceTypeForm__rateInput` |
+| State modifiers | `.nfc-tap-prompt--processing` | `.nfcTapPromptProcessing` |
+
+## File Structure
+
+Every component or page that needs styling must have a co-located CSS Module file:
+
+```
+src/presentation/components/mbc/FeeBreakdown/
+├── index.tsx
+└── fee-breakdown.module.css
+```
+
+### File Naming
+
+| Item | Convention | Example |
+|------|-----------|---------|
+| CSS Module file | `kebab-case.module.css` | `fee-breakdown.module.css` |
+| CSS class names | `kebab-case` with BEM `__` and `--` | `.fee-breakdown__total-row` |
+
+## Tailwind v4 `@reference` Directive
+
+Every CSS Module file that uses `@apply` **must** include `@reference "tailwindcss"` at the top:
+
+```css
+@reference "tailwindcss";
+
+.nfc-tap-prompt {
+  @apply flex flex-col items-center gap-3 rounded-xl border-2 border-dashed border-gray-300 p-8 text-center;
+}
+```
+
+## Accessing kebab-case Classes in JSX
+
+Since kebab-case class names contain hyphens, use bracket notation to access them from the styles object:
+
+```tsx
+import styles from './balance-display.module.css';
+
+// Bracket notation for kebab-case
+<div className={styles['balance-display']}>
+<p className={styles['balance-display__label']}>Saldo</p>
+```
+
+## Conditional Styling
+
+Define modifier classes and switch between them:
+
+```css
+.role-card {
+  @apply flex w-full flex-col items-center gap-2 rounded-xl border-2 p-6 text-center transition-colors;
+}
+
+.role-card--active {
+  @apply border-blue-500 bg-blue-50 shadow-md;
+}
+
+.role-card--default {
+  @apply border-gray-200 bg-white;
+}
+
+.role-card--default:hover {
+  @apply border-blue-300 bg-gray-50;
+}
+```
+
+```tsx
+<div className={`${styles['role-card']} ${isActive ? styles['role-card--active'] : styles['role-card--default']}`}>
+```
+
+## Color Conventions
+
+| Purpose | Color Family | Example `@apply` |
+|---------|-------------|-------------------|
+| Primary actions | `blue` | `@apply bg-blue-600 text-white hover:bg-blue-700` |
+| Success / positive | `green` | `@apply bg-green-50 text-green-700` |
+| Warning / simulation | `orange` | `@apply bg-orange-50 text-orange-700` |
+| Error / negative | `red` | `@apply bg-red-50 text-red-700` |
+| Neutral / muted | `gray` | `@apply text-gray-500 border-gray-300` |
+| Balance / financial | `blue` | `@apply bg-blue-50 text-blue-700` |
+
+## Typography & Fonts
+
+- **Primary font**: `Poppins` (weights: 200–700). Set globally on `html, body`.
+- **Brand font**: `TelkomselBatikSans` (weights: 400, 700). Brand-specific headings only.
+- Self-hosted in `src/assets/fonts/`. No external CDN links.
+
+## Responsive Design
+
+- Mobile-first. Use Tailwind responsive prefixes inside `@apply`:
+
+```css
+.mbc-role-picker__grid {
+  @apply grid grid-cols-1 gap-4 sm:grid-cols-2;
+}
+```
+
+## Global Styles
+
+- Global styles in `src/global.css`. Keep minimal.
+- Background: `#ecf3fb`. Text: `#4e5764`.
+- Custom CSS properties in `:root`.
+
+## What to Avoid
+
+- **No Tailwind utilities in JSX `className`.** All styling via CSS Module classes with `@apply`.
+- **No camelCase class names.** Use kebab-case with BEM notation.
+- **No inline `style={{}}` props.**
+- **No CSS-in-JS** (styled-components, Emotion).
+- **No arbitrary Tailwind values** (`bg-[#ff0000]`) when a palette color exists.
+- **No global CSS classes** for component-specific styles.
+- **No `clsx` or `classnames` library.** Use template literals with bracket notation.

--- a/src/presentation/components/mbc/BalanceDisplay/balance-display.module.css
+++ b/src/presentation/components/mbc/BalanceDisplay/balance-display.module.css
@@ -1,0 +1,25 @@
+@reference "tailwindcss";
+
+.balance-display {
+    @apply rounded-lg bg-blue-50 p-4;
+}
+
+.balance-display__label {
+    @apply text-sm text-gray-600;
+}
+
+.balance-display__amount {
+    @apply text-2xl font-bold text-blue-700;
+}
+
+.balance-display__change-row {
+    @apply mt-2 text-sm text-gray-500;
+}
+
+.balance-display__change--positive {
+    @apply text-green-600;
+}
+
+.balance-display__change--negative {
+    @apply text-red-600;
+}

--- a/src/presentation/components/mbc/BalanceDisplay/index.tsx
+++ b/src/presentation/components/mbc/BalanceDisplay/index.tsx
@@ -1,5 +1,6 @@
 import type { FC } from 'react';
 import { formatIDR } from '@utils/helpers/mbc.helper';
+import styles from './balance-display.module.css';
 
 export interface BalanceDisplayProps {
   balance: number;
@@ -13,13 +14,13 @@ const BalanceDisplay: FC<BalanceDisplayProps> = ({
   changeAmount,
 }) => {
   return (
-    <div data-testid="balance-display" className="rounded-lg bg-blue-50 p-4">
-      <p className="text-sm text-gray-600">Saldo</p>
-      <p className="text-2xl font-bold text-blue-700">{formatIDR(balance)}</p>
+    <div data-testid="balance-display" className={styles['balance-display']}>
+      <p className={styles['balance-display__label']}>Saldo</p>
+      <p className={styles['balance-display__amount']}>{formatIDR(balance)}</p>
       {previousBalance !== undefined && changeAmount !== undefined && (
-        <div className="mt-2 text-sm text-gray-500">
+        <div className={styles['balance-display__change-row']}>
           <span>{formatIDR(previousBalance)}</span>
-          <span className={changeAmount >= 0 ? 'text-green-600' : 'text-red-600'}>
+          <span className={changeAmount >= 0 ? styles['balance-display__change--positive'] : styles['balance-display__change--negative']}>
             {' '}
             {changeAmount >= 0 ? '+' : ''}
             {formatIDR(changeAmount)}

--- a/src/presentation/components/mbc/CardInfoDisplay/card-info-display.module.css
+++ b/src/presentation/components/mbc/CardInfoDisplay/card-info-display.module.css
@@ -1,0 +1,33 @@
+@reference "tailwindcss";
+
+.card-info-display {
+    @apply space-y-4;
+}
+
+.card-info-display__member-card {
+    @apply rounded-lg bg-white p-4 shadow-sm;
+}
+
+.card-info-display__member-label {
+    @apply text-sm font-semibold text-gray-500;
+}
+
+.card-info-display__member-name {
+    @apply text-xl font-bold;
+}
+
+.card-info-display__member-id {
+    @apply text-sm text-gray-500;
+}
+
+.card-info-display__check-in-card {
+    @apply rounded-lg bg-orange-50 p-4;
+}
+
+.card-info-display__check-in-label {
+    @apply text-sm font-semibold text-orange-700;
+}
+
+.card-info-display__check-in-detail {
+    @apply text-sm;
+}

--- a/src/presentation/components/mbc/CardInfoDisplay/index.tsx
+++ b/src/presentation/components/mbc/CardInfoDisplay/index.tsx
@@ -2,6 +2,7 @@ import type { FC } from 'react';
 import type { CardData, ServiceType } from '@core/services/mbc/models';
 import BalanceDisplay from '@components/mbc/BalanceDisplay';
 import TransactionLogList from '@components/mbc/TransactionLogList';
+import styles from './card-info-display.module.css';
 
 export interface CardInfoDisplayProps {
   cardData: CardData;
@@ -15,12 +16,12 @@ const CardInfoDisplay: FC<CardInfoDisplayProps> = ({ cardData, serviceTypes }) =
   };
 
   return (
-    <div data-testid="card-info-display" className="space-y-4">
+    <div data-testid="card-info-display" className={styles['card-info-display']}>
       {/* Member Identity */}
-      <div className="rounded-lg bg-white p-4 shadow-sm">
-        <h3 className="text-sm font-semibold text-gray-500">Identitas Member</h3>
-        <p className="text-xl font-bold">{cardData.member.name}</p>
-        <p className="text-sm text-gray-500">ID: {cardData.member.memberId}</p>
+      <div className={styles['card-info-display__member-card']}>
+        <h3 className={styles['card-info-display__member-label']}>Identitas Member</h3>
+        <p className={styles['card-info-display__member-name']}>{cardData.member.name}</p>
+        <p className={styles['card-info-display__member-id']}>ID: {cardData.member.memberId}</p>
       </div>
 
       {/* Balance */}
@@ -28,12 +29,12 @@ const CardInfoDisplay: FC<CardInfoDisplayProps> = ({ cardData, serviceTypes }) =
 
       {/* Check-in Status */}
       {cardData.checkIn && (
-        <div className="rounded-lg bg-orange-50 p-4">
-          <h3 className="text-sm font-semibold text-orange-700">Status Check-In Aktif</h3>
-          <p className="text-sm">
+        <div className={styles['card-info-display__check-in-card']}>
+          <h3 className={styles['card-info-display__check-in-label']}>Status Check-In Aktif</h3>
+          <p className={styles['card-info-display__check-in-detail']}>
             Layanan: <strong>{resolveServiceName(cardData.checkIn.serviceTypeId)}</strong>
           </p>
-          <p className="text-sm">
+          <p className={styles['card-info-display__check-in-detail']}>
             Waktu masuk:{' '}
             <strong>
               {new Date(cardData.checkIn.timestamp).toLocaleString('id-ID')}

--- a/src/presentation/components/mbc/FeeBreakdown/fee-breakdown.module.css
+++ b/src/presentation/components/mbc/FeeBreakdown/fee-breakdown.module.css
@@ -1,0 +1,29 @@
+@reference "tailwindcss";
+
+.fee-breakdown {
+    @apply rounded-lg bg-gray-50 p-4;
+}
+
+.fee-breakdown__title {
+    @apply mb-3 text-lg font-semibold;
+}
+
+.fee-breakdown__list {
+    @apply space-y-2 text-sm;
+}
+
+.fee-breakdown__row {
+    @apply flex justify-between;
+}
+
+.fee-breakdown__label {
+    @apply text-gray-600;
+}
+
+.fee-breakdown__value {
+    @apply font-medium;
+}
+
+.fee-breakdown__total-row {
+    @apply flex justify-between border-t pt-2 text-base font-bold;
+}

--- a/src/presentation/components/mbc/FeeBreakdown/index.tsx
+++ b/src/presentation/components/mbc/FeeBreakdown/index.tsx
@@ -1,6 +1,7 @@
 import type { FC } from 'react';
 import type { FeeResult } from '@core/services/mbc/models';
 import { formatIDR } from '@utils/helpers/mbc.helper';
+import styles from './fee-breakdown.module.css';
 
 export interface FeeBreakdownProps {
   feeResult: FeeResult;
@@ -9,32 +10,32 @@ export interface FeeBreakdownProps {
 
 const FeeBreakdown: FC<FeeBreakdownProps> = ({ feeResult, serviceTypeName }) => {
   return (
-    <div data-testid="fee-breakdown" className="rounded-lg bg-gray-50 p-4">
-      <h3 className="mb-3 text-lg font-semibold">Rincian Biaya</h3>
-      <dl className="space-y-2 text-sm">
-        <div className="flex justify-between">
-          <dt className="text-gray-600">Layanan</dt>
-          <dd className="font-medium">{serviceTypeName}</dd>
+    <div data-testid="fee-breakdown" className={styles['fee-breakdown']}>
+      <h3 className={styles['fee-breakdown__title']}>Rincian Biaya</h3>
+      <dl className={styles['fee-breakdown__list']}>
+        <div className={styles['fee-breakdown__row']}>
+          <dt className={styles['fee-breakdown__label']}>Layanan</dt>
+          <dd className={styles['fee-breakdown__value']}>{serviceTypeName}</dd>
         </div>
-        <div className="flex justify-between">
-          <dt className="text-gray-600">Penggunaan</dt>
-          <dd className="font-medium">
+        <div className={styles['fee-breakdown__row']}>
+          <dt className={styles['fee-breakdown__label']}>Penggunaan</dt>
+          <dd className={styles['fee-breakdown__value']}>
             {feeResult.usageUnits} {feeResult.unitLabel}
           </dd>
         </div>
-        <div className="flex justify-between">
-          <dt className="text-gray-600">Tarif</dt>
-          <dd className="font-medium">
+        <div className={styles['fee-breakdown__row']}>
+          <dt className={styles['fee-breakdown__label']}>Tarif</dt>
+          <dd className={styles['fee-breakdown__value']}>
             {formatIDR(feeResult.ratePerUnit)} / {feeResult.unitLabel}
           </dd>
         </div>
         {feeResult.roundingApplied !== 'none' && (
-          <div className="flex justify-between">
-            <dt className="text-gray-600">Pembulatan</dt>
-            <dd className="font-medium">{feeResult.roundingApplied}</dd>
+          <div className={styles['fee-breakdown__row']}>
+            <dt className={styles['fee-breakdown__label']}>Pembulatan</dt>
+            <dd className={styles['fee-breakdown__value']}>{feeResult.roundingApplied}</dd>
           </div>
         )}
-        <div className="flex justify-between border-t pt-2 text-base font-bold">
+        <div className={styles['fee-breakdown__total-row']}>
           <dt>Total</dt>
           <dd>{formatIDR(feeResult.fee)}</dd>
         </div>

--- a/src/presentation/components/mbc/ManualCalcForm/index.tsx
+++ b/src/presentation/components/mbc/ManualCalcForm/index.tsx
@@ -1,6 +1,7 @@
 import type { FC, FormEvent } from 'react';
 import { useState } from 'react';
 import type { ServiceType } from '@core/services/mbc/models';
+import styles from './manual-calc-form.module.css';
 
 export interface ManualCalcFormData {
   checkInTimestamp: string;
@@ -33,13 +34,13 @@ const ManualCalcForm: FC<ManualCalcFormProps> = ({
   };
 
   return (
-    <div data-testid="manual-calc-form" className="rounded-lg border-2 border-dashed border-orange-300 bg-orange-50 p-4">
-      <h3 className="mb-3 text-sm font-semibold text-orange-700">
+    <div data-testid="manual-calc-form" className={styles['manual-calc-form']}>
+      <h3 className={styles['manual-calc-form__heading']}>
         Manual / Offline Calculation
       </h3>
-      <form onSubmit={handleSubmit} className="space-y-3">
+      <form onSubmit={handleSubmit} className={styles['manual-calc-form__form']}>
         <div>
-          <label htmlFor="mc-timestamp" className="block text-sm font-medium text-gray-700">
+          <label htmlFor="mc-timestamp" className={styles['manual-calc-form__label']}>
             Waktu Check-In
           </label>
           <input
@@ -48,11 +49,11 @@ const ManualCalcForm: FC<ManualCalcFormProps> = ({
             value={checkInTimestamp}
             onChange={(e) => setCheckInTimestamp(e.target.value)}
             required
-            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+            className={styles['manual-calc-form__input']}
           />
         </div>
         <div>
-          <label htmlFor="mc-service" className="block text-sm font-medium text-gray-700">
+          <label htmlFor="mc-service" className={styles['manual-calc-form__label']}>
             Layanan
           </label>
           <select
@@ -60,7 +61,7 @@ const ManualCalcForm: FC<ManualCalcFormProps> = ({
             value={serviceTypeId}
             onChange={(e) => setServiceTypeId(e.target.value)}
             required
-            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+            className={styles['manual-calc-form__select']}
           >
             <option value="" disabled>-- Pilih layanan --</option>
             {serviceTypes.map((st) => (
@@ -70,7 +71,7 @@ const ManualCalcForm: FC<ManualCalcFormProps> = ({
         </div>
         <button
           type="submit"
-          className="w-full rounded-md bg-orange-600 px-4 py-2 text-sm font-medium text-white hover:bg-orange-700"
+          className={styles['manual-calc-form__submit-button']}
         >
           Hitung Tarif
         </button>

--- a/src/presentation/components/mbc/ManualCalcForm/manual-calc-form.module.css
+++ b/src/presentation/components/mbc/ManualCalcForm/manual-calc-form.module.css
@@ -1,0 +1,29 @@
+@reference "tailwindcss";
+
+.manual-calc-form {
+    @apply rounded-lg border-2 border-dashed border-orange-300 bg-orange-50 p-4;
+}
+
+.manual-calc-form__heading {
+    @apply mb-3 text-sm font-semibold text-orange-700;
+}
+
+.manual-calc-form__form {
+    @apply space-y-3;
+}
+
+.manual-calc-form__label {
+    @apply block text-sm font-medium text-gray-700;
+}
+
+.manual-calc-form__input {
+    @apply mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm;
+}
+
+.manual-calc-form__select {
+    @apply mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm;
+}
+
+.manual-calc-form__submit-button {
+    @apply w-full rounded-md bg-orange-600 px-4 py-2 text-sm font-medium text-white hover:bg-orange-700;
+}

--- a/src/presentation/components/mbc/NfcTapPrompt/index.tsx
+++ b/src/presentation/components/mbc/NfcTapPrompt/index.tsx
@@ -1,5 +1,6 @@
 import type { FC } from 'react';
 import type { NfcStatus } from '@core/services/mbc/models';
+import styles from './nfc-tap-prompt.module.css';
 
 export interface NfcTapPromptProps {
   nfcStatus: NfcStatus;
@@ -30,17 +31,17 @@ const NfcTapPrompt: FC<NfcTapPromptProps> = ({
       aria-live="polite"
       aria-busy={isProcessing}
       data-testid="nfc-tap-prompt"
-      className="flex flex-col items-center gap-3 rounded-xl border-2 border-dashed border-gray-300 p-8 text-center"
+      className={styles['nfc-tap-prompt']}
       style={{ opacity: isProcessing ? 0.6 : 1 }}
     >
-      <span className="text-5xl" aria-hidden="true">
+      <span className={styles['nfc-tap-prompt__emoji']} aria-hidden="true">
         {config.emoji}
       </span>
-      <p className="text-lg font-medium text-gray-700">
+      <p className={styles['nfc-tap-prompt__status-text']}>
         {label ?? config.text}
       </p>
       {isProcessing && (
-        <p className="text-sm text-gray-500">Sedang memproses...</p>
+        <p className={styles['nfc-tap-prompt__processing-text']}>Sedang memproses...</p>
       )}
     </div>
   );

--- a/src/presentation/components/mbc/NfcTapPrompt/nfc-tap-prompt.module.css
+++ b/src/presentation/components/mbc/NfcTapPrompt/nfc-tap-prompt.module.css
@@ -1,0 +1,17 @@
+@reference "tailwindcss";
+
+.nfc-tap-prompt {
+    @apply flex flex-col items-center gap-3 rounded-xl border-2 border-dashed border-gray-300 p-8 text-center;
+}
+
+.nfc-tap-prompt__emoji {
+    @apply text-5xl;
+}
+
+.nfc-tap-prompt__status-text {
+    @apply text-lg font-medium text-gray-700;
+}
+
+.nfc-tap-prompt__processing-text {
+    @apply text-sm text-gray-500;
+}

--- a/src/presentation/components/mbc/RoleCard/index.tsx
+++ b/src/presentation/components/mbc/RoleCard/index.tsx
@@ -1,5 +1,6 @@
 import type { FC } from 'react';
 import type { RoleOption } from '@controllers/mbc/role-picker.controller';
+import styles from './role-card.module.css';
 
 export interface RoleCardProps {
   role: RoleOption;
@@ -14,17 +15,13 @@ const RoleCard: FC<RoleCardProps> = ({ role, isActive, onSelect }) => {
       onClick={onSelect}
       data-testid={`role-card-${role.id}`}
       aria-pressed={isActive}
-      className={`flex w-full flex-col items-center gap-2 rounded-xl border-2 p-6 text-center transition-colors ${
-        isActive
-          ? 'border-blue-500 bg-blue-50 shadow-md'
-          : 'border-gray-200 bg-white hover:border-blue-300 hover:bg-gray-50'
-      }`}
+      className={`${styles['role-card']} ${isActive ? styles['role-card--active'] : styles['role-card--default']}`}
     >
-      <span className="text-4xl" aria-hidden="true">
+      <span className={styles['role-card__icon']} aria-hidden="true">
         {role.icon}
       </span>
-      <h3 className="text-lg font-semibold">{role.label}</h3>
-      <p className="text-sm text-gray-500">{role.description}</p>
+      <h3 className={styles['role-card__label']}>{role.label}</h3>
+      <p className={styles['role-card__description']}>{role.description}</p>
     </button>
   );
 };

--- a/src/presentation/components/mbc/RoleCard/role-card.module.css
+++ b/src/presentation/components/mbc/RoleCard/role-card.module.css
@@ -1,0 +1,29 @@
+@reference "tailwindcss";
+
+.role-card {
+    @apply flex w-full flex-col items-center gap-2 rounded-xl border-2 p-6 text-center transition-colors;
+}
+
+.role-card--active {
+    @apply border-blue-500 bg-blue-50 shadow-md;
+}
+
+.role-card--default {
+    @apply border-gray-200 bg-white;
+}
+
+.role-card--default:hover {
+    @apply border-blue-300 bg-gray-50;
+}
+
+.role-card__icon {
+    @apply text-4xl;
+}
+
+.role-card__label {
+    @apply text-lg font-semibold;
+}
+
+.role-card__description {
+    @apply text-sm text-gray-500;
+}

--- a/src/presentation/components/mbc/ServiceTypeForm/index.tsx
+++ b/src/presentation/components/mbc/ServiceTypeForm/index.tsx
@@ -1,6 +1,7 @@
 import type { FC, FormEvent } from 'react';
 import { useState } from 'react';
 import type { ServiceType } from '@core/services/mbc/models';
+import styles from './service-type-form.module.css';
 
 export interface ServiceTypeFormProps {
   onSubmit: (data: ServiceType) => void;
@@ -35,9 +36,9 @@ const ServiceTypeForm: FC<ServiceTypeFormProps> = ({
   };
 
   return (
-    <form onSubmit={handleSubmit} data-testid="service-type-form" className="space-y-3">
+    <form onSubmit={handleSubmit} data-testid="service-type-form" className={styles['service-type-form']}>
       <div>
-        <label htmlFor="st-id" className="block text-sm font-medium text-gray-700">ID</label>
+        <label htmlFor="st-id" className={styles['service-type-form__label']}>ID</label>
         <input
           id="st-id"
           type="text"
@@ -47,11 +48,11 @@ const ServiceTypeForm: FC<ServiceTypeFormProps> = ({
           placeholder="parking"
           pattern="^[a-z0-9-]+$"
           required
-          className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm disabled:opacity-50"
+          className={styles['service-type-form__input--disabled']}
         />
       </div>
       <div>
-        <label htmlFor="st-name" className="block text-sm font-medium text-gray-700">Nama</label>
+        <label htmlFor="st-name" className={styles['service-type-form__label']}>Nama</label>
         <input
           id="st-name"
           type="text"
@@ -59,11 +60,11 @@ const ServiceTypeForm: FC<ServiceTypeFormProps> = ({
           onChange={(e) => setDisplayName(e.target.value)}
           placeholder="Parkir"
           required
-          className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+          className={styles['service-type-form__input']}
         />
       </div>
       <div>
-        <label htmlFor="st-activity" className="block text-sm font-medium text-gray-700">Activity Type</label>
+        <label htmlFor="st-activity" className={styles['service-type-form__label']}>Activity Type</label>
         <input
           id="st-activity"
           type="text"
@@ -72,11 +73,11 @@ const ServiceTypeForm: FC<ServiceTypeFormProps> = ({
           placeholder="parking-fee"
           pattern="^[a-z0-9-]+$"
           required
-          className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+          className={styles['service-type-form__input']}
         />
       </div>
       <div>
-        <label htmlFor="st-rate" className="block text-sm font-medium text-gray-700">Tarif (Rp)</label>
+        <label htmlFor="st-rate" className={styles['service-type-form__label']}>Tarif (Rp)</label>
         <input
           id="st-rate"
           type="number"
@@ -84,16 +85,16 @@ const ServiceTypeForm: FC<ServiceTypeFormProps> = ({
           onChange={(e) => setRatePerUnit(e.target.value)}
           min="1"
           required
-          className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+          className={styles['service-type-form__input']}
         />
       </div>
       <div>
-        <label htmlFor="st-unit" className="block text-sm font-medium text-gray-700">Tipe Unit</label>
+        <label htmlFor="st-unit" className={styles['service-type-form__label']}>Tipe Unit</label>
         <select
           id="st-unit"
           value={unitType}
           onChange={(e) => setUnitType(e.target.value as 'per-hour' | 'per-visit' | 'flat-fee')}
-          className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+          className={styles['service-type-form__select']}
         >
           <option value="per-hour">Per Jam</option>
           <option value="per-visit">Per Kunjungan</option>
@@ -101,12 +102,12 @@ const ServiceTypeForm: FC<ServiceTypeFormProps> = ({
         </select>
       </div>
       <div>
-        <label htmlFor="st-rounding" className="block text-sm font-medium text-gray-700">Pembulatan</label>
+        <label htmlFor="st-rounding" className={styles['service-type-form__label']}>Pembulatan</label>
         <select
           id="st-rounding"
           value={roundingStrategy}
           onChange={(e) => setRoundingStrategy(e.target.value as 'ceiling' | 'floor' | 'nearest')}
-          className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+          className={styles['service-type-form__select']}
         >
           <option value="ceiling">Ke Atas (Ceiling)</option>
           <option value="floor">Ke Bawah (Floor)</option>
@@ -115,7 +116,7 @@ const ServiceTypeForm: FC<ServiceTypeFormProps> = ({
       </div>
       <button
         type="submit"
-        className="w-full rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+        className={styles['service-type-form__submit-button']}
       >
         {isEditing ? 'Simpan Perubahan' : 'Tambah Service Type'}
       </button>

--- a/src/presentation/components/mbc/ServiceTypeForm/service-type-form.module.css
+++ b/src/presentation/components/mbc/ServiceTypeForm/service-type-form.module.css
@@ -1,0 +1,25 @@
+@reference "tailwindcss";
+
+.service-type-form {
+    @apply space-y-3;
+}
+
+.service-type-form__label {
+    @apply block text-sm font-medium text-gray-700;
+}
+
+.service-type-form__input {
+    @apply mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm;
+}
+
+.service-type-form__input--disabled {
+    @apply mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm disabled:opacity-50;
+}
+
+.service-type-form__select {
+    @apply mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm;
+}
+
+.service-type-form__submit-button {
+    @apply w-full rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700;
+}

--- a/src/presentation/components/mbc/ServiceTypeSelector/index.tsx
+++ b/src/presentation/components/mbc/ServiceTypeSelector/index.tsx
@@ -1,5 +1,6 @@
 import type { FC } from 'react';
 import type { ServiceType } from '@core/services/mbc/models';
+import styles from './service-type-selector.module.css';
 
 export interface ServiceTypeSelectorProps {
   serviceTypes: ServiceType[];
@@ -16,7 +17,7 @@ const ServiceTypeSelector: FC<ServiceTypeSelectorProps> = ({
 }) => {
   if (serviceTypes.length === 0) {
     return (
-      <div data-testid="service-type-selector" className="rounded-md bg-yellow-50 p-3 text-sm text-yellow-700">
+      <div data-testid="service-type-selector" className={styles['service-type-selector--empty']}>
         Belum ada service type yang dikonfigurasi. Silakan konfigurasi di The Station.
       </div>
     );
@@ -24,7 +25,7 @@ const ServiceTypeSelector: FC<ServiceTypeSelectorProps> = ({
 
   return (
     <div data-testid="service-type-selector">
-      <label htmlFor="service-type-select" className="mb-1 block text-sm font-medium text-gray-700">
+      <label htmlFor="service-type-select" className={styles['service-type-selector__label']}>
         Pilih Layanan
       </label>
       <select
@@ -32,7 +33,7 @@ const ServiceTypeSelector: FC<ServiceTypeSelectorProps> = ({
         value={selectedId ?? ''}
         onChange={(e) => onSelect(e.target.value)}
         disabled={disabled}
-        className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:opacity-50"
+        className={styles['service-type-selector__select']}
       >
         <option value="" disabled>
           -- Pilih layanan --

--- a/src/presentation/components/mbc/ServiceTypeSelector/service-type-selector.module.css
+++ b/src/presentation/components/mbc/ServiceTypeSelector/service-type-selector.module.css
@@ -1,0 +1,13 @@
+@reference "tailwindcss";
+
+.service-type-selector--empty {
+    @apply rounded-md bg-yellow-50 p-3 text-sm text-yellow-700;
+}
+
+.service-type-selector__label {
+    @apply mb-1 block text-sm font-medium text-gray-700;
+}
+
+.service-type-selector__select {
+    @apply w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:opacity-50;
+}

--- a/src/presentation/components/mbc/SimulationBanner/index.tsx
+++ b/src/presentation/components/mbc/SimulationBanner/index.tsx
@@ -1,4 +1,5 @@
 import type { FC } from 'react';
+import styles from './simulation-banner.module.css';
 
 export interface SimulationBannerProps {
   isActive: boolean;
@@ -12,11 +13,11 @@ const SimulationBanner: FC<SimulationBannerProps> = ({ isActive, timestamp }) =>
     <div
       role="alert"
       data-testid="simulation-banner"
-      className="rounded-md bg-yellow-100 border border-yellow-400 px-4 py-2 text-sm text-yellow-800"
+      className={styles['simulation-banner']}
     >
       <strong>⚠️ Mode Simulasi Aktif</strong>
       {timestamp && (
-        <span className="ml-2">
+        <span className={styles['simulation-banner__timestamp']}>
           — Waktu check-in: {new Date(timestamp).toLocaleString('id-ID')}
         </span>
       )}

--- a/src/presentation/components/mbc/SimulationBanner/simulation-banner.module.css
+++ b/src/presentation/components/mbc/SimulationBanner/simulation-banner.module.css
@@ -1,0 +1,9 @@
+@reference "tailwindcss";
+
+.simulation-banner {
+    @apply rounded-md border border-yellow-400 bg-yellow-100 px-4 py-2 text-sm text-yellow-800;
+}
+
+.simulation-banner__timestamp {
+    @apply ml-2;
+}

--- a/src/presentation/components/mbc/TransactionLogList/index.tsx
+++ b/src/presentation/components/mbc/TransactionLogList/index.tsx
@@ -1,6 +1,7 @@
 import type { FC } from 'react';
 import type { TransactionLogEntry, ServiceType } from '@core/services/mbc/models';
 import { formatIDR } from '@utils/helpers/mbc.helper';
+import styles from './transaction-log-list.module.css';
 
 export interface TransactionLogListProps {
   transactions: TransactionLogEntry[];
@@ -29,7 +30,7 @@ const TransactionLogList: FC<TransactionLogListProps> = ({
 
   if (transactions.length === 0) {
     return (
-      <div data-testid="transaction-log" className="py-4 text-center text-sm text-gray-400">
+      <div data-testid="transaction-log" className={styles['transaction-log-list--empty']}>
         Belum ada riwayat transaksi
       </div>
     );
@@ -37,19 +38,19 @@ const TransactionLogList: FC<TransactionLogListProps> = ({
 
   return (
     <div data-testid="transaction-log">
-      <h3 className="mb-2 text-sm font-semibold text-gray-600">Riwayat Transaksi</h3>
-      <ul className="space-y-2">
+      <h3 className={styles['transaction-log-list__heading']}>Riwayat Transaksi</h3>
+      <ul className={styles['transaction-log-list__list']}>
         {transactions.map((tx, index) => (
           <li
             key={`${tx.timestamp}-${index}`}
-            className="flex items-center justify-between rounded-md bg-gray-50 px-3 py-2 text-sm"
+            className={styles['transaction-log-list__item']}
           >
             <div>
-              <p className="font-medium">{resolveServiceName(tx.serviceTypeId)}</p>
-              <p className="text-xs text-gray-400">{formatTimestamp(tx.timestamp)}</p>
+              <p className={styles['transaction-log-list__service-name']}>{resolveServiceName(tx.serviceTypeId)}</p>
+              <p className={styles['transaction-log-list__timestamp']}>{formatTimestamp(tx.timestamp)}</p>
             </div>
             <span
-              className={tx.amount >= 0 ? 'font-semibold text-green-600' : 'font-semibold text-red-600'}
+              className={tx.amount >= 0 ? styles['transaction-log-list__amount--positive'] : styles['transaction-log-list__amount--negative']}
             >
               {tx.amount >= 0 ? '+' : ''}
               {formatIDR(tx.amount)}

--- a/src/presentation/components/mbc/TransactionLogList/transaction-log-list.module.css
+++ b/src/presentation/components/mbc/TransactionLogList/transaction-log-list.module.css
@@ -1,0 +1,33 @@
+@reference "tailwindcss";
+
+.transaction-log-list--empty {
+    @apply py-4 text-center text-sm text-gray-400;
+}
+
+.transaction-log-list__heading {
+    @apply mb-2 text-sm font-semibold text-gray-600;
+}
+
+.transaction-log-list__list {
+    @apply space-y-2;
+}
+
+.transaction-log-list__item {
+    @apply flex items-center justify-between rounded-md bg-gray-50 px-3 py-2 text-sm;
+}
+
+.transaction-log-list__service-name {
+    @apply font-medium;
+}
+
+.transaction-log-list__timestamp {
+    @apply text-xs text-gray-400;
+}
+
+.transaction-log-list__amount--positive {
+    @apply font-semibold text-green-600;
+}
+
+.transaction-log-list__amount--negative {
+    @apply font-semibold text-red-600;
+}

--- a/src/presentation/pages/(mbc)/MbcGate/index.tsx
+++ b/src/presentation/pages/(mbc)/MbcGate/index.tsx
@@ -4,21 +4,22 @@ import type { GateControllerInterface } from '@controllers/mbc/gate.controller';
 import NfcTapPrompt from '@components/mbc/NfcTapPrompt';
 import ServiceTypeSelector from '@components/mbc/ServiceTypeSelector';
 import SimulationBanner from '@components/mbc/SimulationBanner';
+import styles from './mbc-gate.module.css';
 
 const MbcGate: FC = () => {
   const ctrl = container.resolve<GateControllerInterface>('gateController');
 
   return (
-    <main className="mx-auto max-w-lg px-4 py-6">
-      <h1 className="mb-1 text-xl font-bold">🚪 The Gate</h1>
-      <p className="mb-4 text-sm text-gray-500">Check-in member dengan NFC</p>
+    <main className={styles['mbc-gate']}>
+      <h1 className={styles['mbc-gate__title']}>🚪 The Gate</h1>
+      <p className={styles['mbc-gate__subtitle']}>Check-in member dengan NFC</p>
 
       <SimulationBanner
         isActive={ctrl.simulationMode}
         timestamp={ctrl.simulationTimestamp}
       />
 
-      <div className="mt-4 space-y-4">
+      <div className={styles['mbc-gate__content']}>
         <ServiceTypeSelector
           serviceTypes={ctrl.serviceTypes}
           selectedId={ctrl.selectedServiceType?.id ?? null}
@@ -27,8 +28,8 @@ const MbcGate: FC = () => {
         />
 
         {/* Simulation Mode Toggle */}
-        <div className="flex items-center gap-3">
-          <label htmlFor="sim-toggle" className="text-sm font-medium text-gray-700">
+        <div className={styles['mbc-gate__toggle-row']}>
+          <label htmlFor="sim-toggle" className={styles['mbc-gate__toggle-label']}>
             Mode Simulasi
           </label>
           <button
@@ -37,21 +38,17 @@ const MbcGate: FC = () => {
             role="switch"
             aria-checked={ctrl.simulationMode}
             onClick={ctrl.onToggleSimulation}
-            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-              ctrl.simulationMode ? 'bg-yellow-500' : 'bg-gray-300'
-            }`}
+            className={ctrl.simulationMode ? styles['mbc-gate__switch--on'] : styles['mbc-gate__switch--off']}
           >
             <span
-              className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                ctrl.simulationMode ? 'translate-x-6' : 'translate-x-1'
-              }`}
+              className={ctrl.simulationMode ? styles['mbc-gate__switch-knob--on'] : styles['mbc-gate__switch-knob--off']}
             />
           </button>
         </div>
 
         {ctrl.simulationMode && (
           <div>
-            <label htmlFor="sim-time" className="block text-sm font-medium text-gray-700">
+            <label htmlFor="sim-time" className={styles['mbc-gate__label']}>
               Waktu Check-In (Simulasi)
             </label>
             <input
@@ -59,7 +56,7 @@ const MbcGate: FC = () => {
               type="datetime-local"
               value={ctrl.simulationTimestamp ?? ''}
               onChange={(e) => ctrl.onSetSimulationTimestamp(e.target.value)}
-              className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+              className={styles['mbc-gate__input']}
             />
           </div>
         )}
@@ -68,7 +65,7 @@ const MbcGate: FC = () => {
           type="button"
           onClick={ctrl.onCheckIn}
           disabled={ctrl.isProcessing || !ctrl.selectedServiceType}
-          className="w-full rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+          className={styles['mbc-gate__primary-button']}
         >
           Check-In
         </button>
@@ -76,14 +73,14 @@ const MbcGate: FC = () => {
         <NfcTapPrompt nfcStatus={ctrl.nfcStatus} isProcessing={ctrl.isProcessing} />
 
         {ctrl.error && (
-          <div role="alert" className="rounded-md bg-red-50 p-3 text-sm text-red-700">
+          <div role="alert" className={styles['mbc-gate__error-alert']}>
             {ctrl.error}
           </div>
         )}
 
         {ctrl.lastResult && ctrl.nfcStatus === 'success' && (
-          <output className="rounded-md bg-green-50 p-4 text-sm">
-            <p className="font-semibold text-green-700">✅ Check-in berhasil</p>
+          <output className={styles['mbc-gate__success-output']}>
+            <p className={styles['mbc-gate__success-title']}>✅ Check-in berhasil</p>
             <p>Member: <strong>{ctrl.lastResult.memberName}</strong></p>
             <p>Layanan: <strong>{ctrl.lastResult.serviceTypeName}</strong></p>
             <p>Waktu masuk: <strong>{new Date(ctrl.lastResult.entryTime).toLocaleString('id-ID')}</strong></p>

--- a/src/presentation/pages/(mbc)/MbcGate/mbc-gate.module.css
+++ b/src/presentation/pages/(mbc)/MbcGate/mbc-gate.module.css
@@ -1,0 +1,65 @@
+@reference "tailwindcss";
+
+.mbc-gate {
+    @apply mx-auto max-w-lg px-4 py-6;
+}
+
+.mbc-gate__title {
+    @apply mb-1 text-xl font-bold;
+}
+
+.mbc-gate__subtitle {
+    @apply mb-4 text-sm text-gray-500;
+}
+
+.mbc-gate__content {
+    @apply mt-4 space-y-4;
+}
+
+.mbc-gate__toggle-row {
+    @apply flex items-center gap-3;
+}
+
+.mbc-gate__toggle-label {
+    @apply text-sm font-medium text-gray-700;
+}
+
+.mbc-gate__switch--on {
+    @apply relative inline-flex h-6 w-11 items-center rounded-full bg-yellow-500 transition-colors;
+}
+
+.mbc-gate__switch--off {
+    @apply relative inline-flex h-6 w-11 items-center rounded-full bg-gray-300 transition-colors;
+}
+
+.mbc-gate__switch-knob--on {
+    @apply inline-block h-4 w-4 transform rounded-full bg-white transition-transform translate-x-6;
+}
+
+.mbc-gate__switch-knob--off {
+    @apply inline-block h-4 w-4 transform rounded-full bg-white transition-transform translate-x-1;
+}
+
+.mbc-gate__label {
+    @apply block text-sm font-medium text-gray-700;
+}
+
+.mbc-gate__input {
+    @apply mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm;
+}
+
+.mbc-gate__primary-button {
+    @apply w-full rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50;
+}
+
+.mbc-gate__error-alert {
+    @apply rounded-md bg-red-50 p-3 text-sm text-red-700;
+}
+
+.mbc-gate__success-output {
+    @apply rounded-md bg-green-50 p-4 text-sm;
+}
+
+.mbc-gate__success-title {
+    @apply font-semibold text-green-700;
+}

--- a/src/presentation/pages/(mbc)/MbcRolePicker/index.tsx
+++ b/src/presentation/pages/(mbc)/MbcRolePicker/index.tsx
@@ -3,17 +3,18 @@ import { useNavigate } from '@tanstack/react-router';
 import container from '@di/container';
 import type { RolePickerControllerInterface } from '@controllers/mbc/role-picker.controller';
 import RoleCard from '@components/mbc/RoleCard';
+import styles from './mbc-role-picker.module.css';
 
 const MbcRolePicker: FC = () => {
   const ctrl = container.resolve<RolePickerControllerInterface>('rolePickerController');
   const navigate = useNavigate();
 
   return (
-    <main className="mx-auto max-w-2xl px-4 py-8">
-      <h1 className="mb-2 text-center text-2xl font-bold">Membership Benefit Card</h1>
-      <p className="mb-8 text-center text-gray-500">Pilih mode operasi</p>
+    <main className={styles['mbc-role-picker']}>
+      <h1 className={styles['mbc-role-picker__title']}>Membership Benefit Card</h1>
+      <p className={styles['mbc-role-picker__subtitle']}>Pilih mode operasi</p>
 
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+      <div className={styles['mbc-role-picker__grid']}>
         {ctrl.roles.map((role) => (
           <RoleCard
             key={role.id}

--- a/src/presentation/pages/(mbc)/MbcRolePicker/mbc-role-picker.module.css
+++ b/src/presentation/pages/(mbc)/MbcRolePicker/mbc-role-picker.module.css
@@ -1,0 +1,17 @@
+@reference "tailwindcss";
+
+.mbc-role-picker {
+    @apply mx-auto max-w-2xl px-4 py-8;
+}
+
+.mbc-role-picker__title {
+    @apply mb-2 text-center text-2xl font-bold;
+}
+
+.mbc-role-picker__subtitle {
+    @apply mb-8 text-center text-gray-500;
+}
+
+.mbc-role-picker__grid {
+    @apply grid grid-cols-1 gap-4 sm:grid-cols-2;
+}

--- a/src/presentation/pages/(mbc)/MbcScout/index.tsx
+++ b/src/presentation/pages/(mbc)/MbcScout/index.tsx
@@ -3,21 +3,22 @@ import container from '@di/container';
 import type { ScoutControllerInterface } from '@controllers/mbc/scout.controller';
 import NfcTapPrompt from '@components/mbc/NfcTapPrompt';
 import CardInfoDisplay from '@components/mbc/CardInfoDisplay';
+import styles from './mbc-scout.module.css';
 
 const MbcScout: FC = () => {
   const ctrl = container.resolve<ScoutControllerInterface>('scoutController');
 
   return (
-    <main className="mx-auto max-w-lg px-4 py-6">
-      <h1 className="mb-1 text-xl font-bold">🔍 The Scout</h1>
-      <p className="mb-4 text-sm text-gray-500">Lihat isi kartu member</p>
+    <main className={styles['mbc-scout']}>
+      <h1 className={styles['mbc-scout__title']}>🔍 The Scout</h1>
+      <p className={styles['mbc-scout__subtitle']}>Lihat isi kartu member</p>
 
-      <div className="space-y-4">
+      <div className={styles['mbc-scout__content']}>
         <button
           type="button"
           onClick={ctrl.onReadCard}
           disabled={ctrl.isReading}
-          className="w-full rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+          className={styles['mbc-scout__primary-button']}
         >
           Baca Kartu
         </button>
@@ -28,7 +29,7 @@ const MbcScout: FC = () => {
         />
 
         {ctrl.error && (
-          <div role="alert" className="rounded-md bg-red-50 p-3 text-sm text-red-700">
+          <div role="alert" className={styles['mbc-scout__error-alert']}>
             {ctrl.error}
           </div>
         )}

--- a/src/presentation/pages/(mbc)/MbcScout/mbc-scout.module.css
+++ b/src/presentation/pages/(mbc)/MbcScout/mbc-scout.module.css
@@ -1,0 +1,25 @@
+@reference "tailwindcss";
+
+.mbc-scout {
+    @apply mx-auto max-w-lg px-4 py-6;
+}
+
+.mbc-scout__title {
+    @apply mb-1 text-xl font-bold;
+}
+
+.mbc-scout__subtitle {
+    @apply mb-4 text-sm text-gray-500;
+}
+
+.mbc-scout__content {
+    @apply space-y-4;
+}
+
+.mbc-scout__primary-button {
+    @apply w-full rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50;
+}
+
+.mbc-scout__error-alert {
+    @apply rounded-md bg-red-50 p-3 text-sm text-red-700;
+}

--- a/src/presentation/pages/(mbc)/MbcStation/index.tsx
+++ b/src/presentation/pages/(mbc)/MbcStation/index.tsx
@@ -6,6 +6,7 @@ import NfcTapPrompt from '@components/mbc/NfcTapPrompt';
 import BalanceDisplay from '@components/mbc/BalanceDisplay';
 import ServiceTypeForm from '@components/mbc/ServiceTypeForm';
 import { formatIDR } from '@utils/helpers/mbc.helper';
+import styles from './mbc-station.module.css';
 
 type Tab = 'register' | 'topup' | 'config';
 
@@ -23,27 +24,25 @@ const MbcStation: FC = () => {
   ];
 
   return (
-    <main className="mx-auto max-w-lg px-4 py-6">
-      <h1 className="mb-1 text-xl font-bold">🏢 The Station</h1>
-      <p className="mb-4 text-sm text-gray-500">Admin: Registrasi, Top-Up, Konfigurasi</p>
+    <main className={styles['mbc-station']}>
+      <h1 className={styles['mbc-station__title']}>🏢 The Station</h1>
+      <p className={styles['mbc-station__subtitle']}>Admin: Registrasi, Top-Up, Konfigurasi</p>
 
       {ctrl.storageWarning && (
-        <div role="alert" className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-700">
+        <div role="alert" className={styles['mbc-station__storage-warning']}>
           ⚠️ {ctrl.storageWarning}
         </div>
       )}
 
       {/* Tabs */}
-      <div className="mb-4 flex gap-1 rounded-lg bg-gray-100 p-1" role="tablist">
+      <div className={styles['mbc-station__tab-list']} role="tablist">
         {tabs.map((tab) => (
           <button
             key={tab.id}
             role="tab"
             aria-selected={activeTab === tab.id}
             onClick={() => setActiveTab(tab.id)}
-            className={`flex-1 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
-              activeTab === tab.id ? 'bg-white shadow-sm' : 'text-gray-500 hover:text-gray-700'
-            }`}
+            className={activeTab === tab.id ? styles['mbc-station__tab--active'] : styles['mbc-station__tab--inactive']}
           >
             {tab.label}
           </button>
@@ -52,23 +51,23 @@ const MbcStation: FC = () => {
 
       {/* Registration Tab */}
       {activeTab === 'register' && (
-        <div className="space-y-4">
+        <div className={styles['mbc-station__section']}>
           <form
             onSubmit={(e) => {
               e.preventDefault();
               ctrl.onRegister({ name: regName, memberId: regMemberId });
             }}
-            className="space-y-3"
+            className={styles['mbc-station__form-group']}
           >
             <div>
-              <label htmlFor="reg-name" className="block text-sm font-medium text-gray-700">Nama</label>
-              <input id="reg-name" type="text" value={regName} onChange={(e) => setRegName(e.target.value)} required className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm" />
+              <label htmlFor="reg-name" className={styles['mbc-station__label']}>Nama</label>
+              <input id="reg-name" type="text" value={regName} onChange={(e) => setRegName(e.target.value)} required className={styles['mbc-station__input']} />
             </div>
             <div>
-              <label htmlFor="reg-id" className="block text-sm font-medium text-gray-700">Member ID</label>
-              <input id="reg-id" type="text" value={regMemberId} onChange={(e) => setRegMemberId(e.target.value)} required className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm" />
+              <label htmlFor="reg-id" className={styles['mbc-station__label']}>Member ID</label>
+              <input id="reg-id" type="text" value={regMemberId} onChange={(e) => setRegMemberId(e.target.value)} required className={styles['mbc-station__input']} />
             </div>
-            <button type="submit" disabled={ctrl.isProcessing} className="w-full rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50">
+            <button type="submit" disabled={ctrl.isProcessing} className={styles['mbc-station__primary-button']}>
               Registrasi Kartu
             </button>
           </form>
@@ -78,19 +77,19 @@ const MbcStation: FC = () => {
 
       {/* Top-Up Tab */}
       {activeTab === 'topup' && (
-        <div className="space-y-4">
+        <div className={styles['mbc-station__section']}>
           <form
             onSubmit={(e) => {
               e.preventDefault();
               ctrl.onTopUp({ amount: Number.parseInt(topUpAmount, 10) });
             }}
-            className="space-y-3"
+            className={styles['mbc-station__form-group']}
           >
             <div>
-              <label htmlFor="topup-amount" className="block text-sm font-medium text-gray-700">Jumlah (Rp)</label>
-              <input id="topup-amount" type="number" value={topUpAmount} onChange={(e) => setTopUpAmount(e.target.value)} min="1" required className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm" />
+              <label htmlFor="topup-amount" className={styles['mbc-station__label']}>Jumlah (Rp)</label>
+              <input id="topup-amount" type="number" value={topUpAmount} onChange={(e) => setTopUpAmount(e.target.value)} min="1" required className={styles['mbc-station__input']} />
             </div>
-            <button type="submit" disabled={ctrl.isProcessing} className="w-full rounded-md bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700 disabled:opacity-50">
+            <button type="submit" disabled={ctrl.isProcessing} className={styles['mbc-station__secondary-button']}>
               Top-Up Saldo
             </button>
           </form>
@@ -107,24 +106,24 @@ const MbcStation: FC = () => {
 
       {/* Service Config Tab */}
       {activeTab === 'config' && (
-        <div className="space-y-4">
+        <div className={styles['mbc-station__section']}>
           <ServiceTypeForm onSubmit={(data) => ctrl.onAddServiceType(data)} />
-          <div className="space-y-2">
-            <h3 className="text-sm font-semibold text-gray-600">Service Types Terdaftar</h3>
+          <div className={styles['mbc-station__config-list']}>
+            <h3 className={styles['mbc-station__config-heading']}>Service Types Terdaftar</h3>
             {ctrl.serviceTypes.length === 0 ? (
-              <p className="text-sm text-gray-400">Belum ada service type</p>
+              <p className={styles['mbc-station__config--empty']}>Belum ada service type</p>
             ) : (
-              <ul className="space-y-2">
+              <ul className={styles['mbc-station__config-list']}>
                 {ctrl.serviceTypes.map((st) => (
-                  <li key={st.id} className="flex items-center justify-between rounded-md bg-gray-50 px-3 py-2 text-sm">
+                  <li key={st.id} className={styles['mbc-station__config-item']}>
                     <div>
-                      <p className="font-medium">{st.displayName}</p>
-                      <p className="text-xs text-gray-400">{formatIDR(st.pricing.ratePerUnit)} / {st.pricing.unitType}</p>
+                      <p className={styles['mbc-station__config-item-name']}>{st.displayName}</p>
+                      <p className={styles['mbc-station__config-item-rate']}>{formatIDR(st.pricing.ratePerUnit)} / {st.pricing.unitType}</p>
                     </div>
                     <button
                       type="button"
                       onClick={() => ctrl.onRemoveServiceType(st.id)}
-                      className="text-red-500 hover:text-red-700"
+                      className={styles['mbc-station__remove-button']}
                       aria-label={`Hapus ${st.displayName}`}
                     >
                       ✕
@@ -139,12 +138,12 @@ const MbcStation: FC = () => {
 
       {/* Error/Success Messages */}
       {ctrl.error && (
-        <div role="alert" className="mt-4 rounded-md bg-red-50 p-3 text-sm text-red-700">
+        <div role="alert" className={styles['mbc-station__error-alert']}>
           {ctrl.error}
         </div>
       )}
       {ctrl.lastResult && ctrl.nfcStatus === 'success' && (
-        <output className="mt-4 block rounded-md bg-green-50 p-3 text-sm text-green-700">
+        <output className={styles['mbc-station__success-output']}>
           ✅ {ctrl.lastResult.type === 'registration' ? 'Registrasi berhasil' : 'Top-up berhasil'} — {ctrl.lastResult.memberName}
         </output>
       )}

--- a/src/presentation/pages/(mbc)/MbcStation/mbc-station.module.css
+++ b/src/presentation/pages/(mbc)/MbcStation/mbc-station.module.css
@@ -1,0 +1,93 @@
+@reference "tailwindcss";
+
+.mbc-station {
+    @apply mx-auto max-w-lg px-4 py-6;
+}
+
+.mbc-station__title {
+    @apply mb-1 text-xl font-bold;
+}
+
+.mbc-station__subtitle {
+    @apply mb-4 text-sm text-gray-500;
+}
+
+.mbc-station__storage-warning {
+    @apply mb-4 rounded-md bg-red-50 p-3 text-sm text-red-700;
+}
+
+.mbc-station__tab-list {
+    @apply mb-4 flex gap-1 rounded-lg bg-gray-100 p-1;
+}
+
+.mbc-station__tab--active {
+    @apply flex-1 rounded-md bg-white px-3 py-2 text-sm font-medium shadow-sm transition-colors;
+}
+
+.mbc-station__tab--inactive {
+    @apply flex-1 rounded-md px-3 py-2 text-sm font-medium text-gray-500 transition-colors;
+}
+
+.mbc-station__tab--inactive:hover {
+    @apply text-gray-700;
+}
+
+.mbc-station__section {
+    @apply space-y-4;
+}
+
+.mbc-station__form-group {
+    @apply space-y-3;
+}
+
+.mbc-station__label {
+    @apply block text-sm font-medium text-gray-700;
+}
+
+.mbc-station__input {
+    @apply mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm;
+}
+
+.mbc-station__primary-button {
+    @apply w-full rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50;
+}
+
+.mbc-station__secondary-button {
+    @apply w-full rounded-md bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700 disabled:opacity-50;
+}
+
+.mbc-station__config-heading {
+    @apply text-sm font-semibold text-gray-600;
+}
+
+.mbc-station__config--empty {
+    @apply text-sm text-gray-400;
+}
+
+.mbc-station__config-list {
+    @apply space-y-2;
+}
+
+.mbc-station__config-item {
+    @apply flex items-center justify-between rounded-md bg-gray-50 px-3 py-2 text-sm;
+}
+
+.mbc-station__config-item-name {
+    @apply font-medium;
+}
+
+.mbc-station__config-item-rate {
+    @apply text-xs text-gray-400;
+}
+
+.mbc-station__remove-button {
+    @apply text-red-500 hover:text-red-700;
+}
+
+.mbc-station__error-alert {
+    @apply mt-4 rounded-md bg-red-50 p-3 text-sm text-red-700;
+}
+
+.mbc-station__success-output {
+    @apply mt-4 block rounded-md bg-green-50 p-3 text-sm text-green-700;
+}

--- a/src/presentation/pages/(mbc)/MbcTerminal/index.tsx
+++ b/src/presentation/pages/(mbc)/MbcTerminal/index.tsx
@@ -6,19 +6,20 @@ import FeeBreakdown from '@components/mbc/FeeBreakdown';
 import BalanceDisplay from '@components/mbc/BalanceDisplay';
 import ManualCalcForm from '@components/mbc/ManualCalcForm';
 import { formatIDR } from '@utils/helpers/mbc.helper';
+import styles from './mbc-terminal.module.css';
 
 const MbcTerminal: FC = () => {
   const ctrl = container.resolve<TerminalControllerInterface>('terminalController');
 
   return (
-    <main className="mx-auto max-w-lg px-4 py-6">
-      <h1 className="mb-1 text-xl font-bold">💳 The Terminal</h1>
-      <p className="mb-4 text-sm text-gray-500">Check-out dan kalkulasi tarif</p>
+    <main className={styles['mbc-terminal']}>
+      <h1 className={styles['mbc-terminal__title']}>💳 The Terminal</h1>
+      <p className={styles['mbc-terminal__subtitle']}>Check-out dan kalkulasi tarif</p>
 
-      <div className="space-y-4">
+      <div className={styles['mbc-terminal__content']}>
         {/* Manual Mode Toggle */}
-        <div className="flex items-center gap-3">
-          <label htmlFor="manual-toggle" className="text-sm font-medium text-gray-700">
+        <div className={styles['mbc-terminal__toggle-row']}>
+          <label htmlFor="manual-toggle" className={styles['mbc-terminal__toggle-label']}>
             Kalkulasi Manual
           </label>
           <button
@@ -27,14 +28,10 @@ const MbcTerminal: FC = () => {
             role="switch"
             aria-checked={ctrl.isManualMode}
             onClick={ctrl.onToggleManualMode}
-            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-              ctrl.isManualMode ? 'bg-orange-500' : 'bg-gray-300'
-            }`}
+            className={ctrl.isManualMode ? styles['mbc-terminal__switch--on'] : styles['mbc-terminal__switch--off']}
           >
             <span
-              className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                ctrl.isManualMode ? 'translate-x-6' : 'translate-x-1'
-              }`}
+              className={ctrl.isManualMode ? styles['mbc-terminal__switch-knob--on'] : styles['mbc-terminal__switch-knob--off']}
             />
           </button>
         </div>
@@ -48,10 +45,10 @@ const MbcTerminal: FC = () => {
 
         {/* Manual Result */}
         {ctrl.manualResult && (
-          <div className="rounded-lg bg-orange-50 p-4">
-            <h3 className="mb-2 text-sm font-semibold text-orange-700">Hasil Kalkulasi Manual</h3>
-            <p className="text-2xl font-bold">{formatIDR(ctrl.manualResult.fee)}</p>
-            <p className="text-sm text-gray-500">
+          <div className={styles['mbc-terminal__manual-result-card']}>
+            <h3 className={styles['mbc-terminal__manual-result-heading']}>Hasil Kalkulasi Manual</h3>
+            <p className={styles['mbc-terminal__manual-result-amount']}>{formatIDR(ctrl.manualResult.fee)}</p>
+            <p className={styles['mbc-terminal__manual-result-detail']}>
               {ctrl.manualResult.usageUnits} {ctrl.manualResult.unitLabel} × {formatIDR(ctrl.manualResult.ratePerUnit)}
             </p>
           </div>
@@ -64,7 +61,7 @@ const MbcTerminal: FC = () => {
               type="button"
               onClick={ctrl.onCheckOut}
               disabled={ctrl.isProcessing}
-              className="w-full rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+              className={styles['mbc-terminal__primary-button']}
             >
               Check-Out
             </button>
@@ -75,8 +72,8 @@ const MbcTerminal: FC = () => {
 
         {/* Check-Out Result */}
         {ctrl.lastResult && ctrl.nfcStatus === 'success' && (
-          <div className="space-y-3">
-            <output className="block rounded-md bg-green-50 p-3 text-sm text-green-700">
+          <div className={styles['mbc-terminal__result-section']}>
+            <output className={styles['mbc-terminal__success-output']}>
               ✅ Check-out berhasil — {ctrl.lastResult.serviceTypeName}
             </output>
             <FeeBreakdown
@@ -89,7 +86,7 @@ const MbcTerminal: FC = () => {
 
         {/* Error */}
         {ctrl.error && (
-          <div role="alert" className="rounded-md bg-red-50 p-3 text-sm text-red-700">
+          <div role="alert" className={styles['mbc-terminal__error-alert']}>
             {ctrl.error}
           </div>
         )}

--- a/src/presentation/pages/(mbc)/MbcTerminal/mbc-terminal.module.css
+++ b/src/presentation/pages/(mbc)/MbcTerminal/mbc-terminal.module.css
@@ -1,0 +1,73 @@
+@reference "tailwindcss";
+
+.mbc-terminal {
+    @apply mx-auto max-w-lg px-4 py-6;
+}
+
+.mbc-terminal__title {
+    @apply mb-1 text-xl font-bold;
+}
+
+.mbc-terminal__subtitle {
+    @apply mb-4 text-sm text-gray-500;
+}
+
+.mbc-terminal__content {
+    @apply space-y-4;
+}
+
+.mbc-terminal__toggle-row {
+    @apply flex items-center gap-3;
+}
+
+.mbc-terminal__toggle-label {
+    @apply text-sm font-medium text-gray-700;
+}
+
+.mbc-terminal__switch--on {
+    @apply relative inline-flex h-6 w-11 items-center rounded-full bg-orange-500 transition-colors;
+}
+
+.mbc-terminal__switch--off {
+    @apply relative inline-flex h-6 w-11 items-center rounded-full bg-gray-300 transition-colors;
+}
+
+.mbc-terminal__switch-knob--on {
+    @apply inline-block h-4 w-4 transform rounded-full bg-white transition-transform translate-x-6;
+}
+
+.mbc-terminal__switch-knob--off {
+    @apply inline-block h-4 w-4 transform rounded-full bg-white transition-transform translate-x-1;
+}
+
+.mbc-terminal__manual-result-card {
+    @apply rounded-lg bg-orange-50 p-4;
+}
+
+.mbc-terminal__manual-result-heading {
+    @apply mb-2 text-sm font-semibold text-orange-700;
+}
+
+.mbc-terminal__manual-result-amount {
+    @apply text-2xl font-bold;
+}
+
+.mbc-terminal__manual-result-detail {
+    @apply text-sm text-gray-500;
+}
+
+.mbc-terminal__primary-button {
+    @apply w-full rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50;
+}
+
+.mbc-terminal__result-section {
+    @apply space-y-3;
+}
+
+.mbc-terminal__success-output {
+    @apply block rounded-md bg-green-50 p-3 text-sm text-green-700;
+}
+
+.mbc-terminal__error-alert {
+    @apply rounded-md bg-red-50 p-3 text-sm text-red-700;
+}


### PR DESCRIPTION
## Changes

Migrate all inline Tailwind utilities to CSS Modules with `@apply` and SMACSS + BEM naming.

### What
- 15 CSS Module files created (10 components + 5 pages)
- 15 TSX files updated to use `styles['block__element']` bracket notation
- Steering document `styling-rules.md` updated with BEM conventions

### Naming Convention
```
.balance-display {}                    /* Block */
.balance-display__label {}             /* Element */
.balance-display__change--positive {}  /* Modifier */
```

### Testing
- `npm run build` ✅
- `npx vitest --run` ✅ 119 passed

Closes #49